### PR TITLE
Update Gravatar URLs to use HTTPS

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -615,15 +615,15 @@ span.tag {
 }
 
 #karax {
-  background-image: url("http://www.gravatar.com/avatar/6275fdd9f48ec9184c5d6511d525c563?s=100&d=identicon");
+  background-image: url("https://www.gravatar.com/avatar/6275fdd9f48ec9184c5d6511d525c563?s=100&d=identicon");
 }
 
 #frag {
-  background-image: url("http://www.gravatar.com/avatar/6275fdd8f48ec9184c5d6511d525c563?s=100&d=identicon");
+  background-image: url("https://www.gravatar.com/avatar/6275fdd8f48ec9184c5d6511d525c563?s=100&d=identicon");
 }
 
 #nimx {
-  background-image: url("http://www.gravatar.com/avatar/6275fdd7f48ec9184c5d6511d525c563?s=100&d=identicon");
+  background-image: url("https://www.gravatar.com/avatar/6275fdd7f48ec9184c5d6511d525c563?s=100&d=identicon");
 }
 
 // Styles for the donate section.
@@ -921,7 +921,7 @@ blockquote {
     top: 0;
     background: linear-gradient(to right, transparent, $menu-background-color);
   }
-  
+
   .page-title {
     // Compensate for the fixed header.
     padding-top: 70px;


### PR DESCRIPTION
Gravatars shown on the home page use HTTP rather than HTTPS, causing mixed content warnings. This updates Gravatar URLs to use HTTPS.