### PR TITLE
`icc` is the Intel C compiler

### DIFF
--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -104,7 +104,7 @@ Change the value of the ``cc`` variable to one of the following:
 |``vcc``           | Microsoft's Visual C++                      |
 |``gcc``           | Gnu C                                       |
 |``llvm_gcc``      | LLVM-GCC compiler                           |
-|``icc``           | Intel C++ compiler                          |
+|``icc``           | Intel C compiler                            |
 |``clang``         | Clang compiler                              |
 |``ucc``           | Generic UNIX C compiler                     |
 


### PR DESCRIPTION
The Intel C++ compiler is `icpc`. I'm inclined to believe compilation is done using `icc` and not `icpc`, but someone ought to check before merging.