### PR TITLE
Some unifications in installation pages

### DIFF
--- a/jekyll/install_unix.md
+++ b/jekyll/install_unix.md
@@ -41,8 +41,8 @@ The compiler and tool binaries live inside the ``bin`` directory.
 It is common for Nim developers to include two directories in their
 [``PATH`` environment variable](https://en.wikipedia.org/wiki/PATH_(variable)):
 
-* the aforementioned ``bin`` folder
-* ``~/.nimble/bin``
+* the aforementioned ``bin`` directory
+* ``~/.nimble/bin`` (where ``~`` is the home directory)
 
 # Notes about compiler dependencies
 

--- a/jekyll/install_windows.md
+++ b/jekyll/install_windows.md
@@ -42,12 +42,12 @@ directory.
 
 ## Configuring the ``PATH`` environment variable
 
-The binaries from the zip file live inside the ``bin`` folder.
+The binaries from the zip file live inside the ``bin`` directory.
 It is common for Nim developers to include two directories in their
 [``PATH`` environment variable](https://en.wikipedia.org/wiki/PATH_(variable)):
 
-* the aforementioned ``bin`` folder
-* ``~/.nimble/bin`` (where ``~`` is ``C:\Users\username\.nimble``)
+* the aforementioned ``bin`` directory
+* ``%USERPROFILE%\.nimble\bin`` (where ``%USERPROFILE%`` is the home directory)
 
 The zip file includes a simple application called ``finish.exe`` that can
 attempt to add the first directory into your ``PATH``.


### PR DESCRIPTION
https://ss64.com/nt/syntax-variables.html

> USERPROFILE: This is equivalent to the $HOME environment variable in Unix/Linux