### PR TITLE
Improve the look of "Community" links.

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -216,7 +216,7 @@ echo("Average line length: ",
         <h2>Forum</h2>
         <h3>Threaded communication</h3>
         <a href="https://forum.nim-lang.org">
-          <i class="fa fa-comments" aria-hidden="true"></i><nobr>forum.nim-lang.org</nobr>
+          <i class="fa fa-comments" aria-hidden="true"></i><span style="white-space: nowrap">forum.nim-lang.org</span>
         </a>
 
       </div>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -216,8 +216,7 @@ echo("Average line length: ",
         <h2>Forum</h2>
         <h3>Threaded communication</h3>
         <a href="https://forum.nim-lang.org">
-          <i class="fa fa-comments" aria-hidden="true"></i>
-          https://forum.nim-lang.org
+          <i class="fa fa-comments" aria-hidden="true"></i><nobr>forum.nim-lang.org</nobr>
         </a>
 
       </div>
@@ -225,8 +224,7 @@ echo("Average line length: ",
         <h2>GitHub issues</h2>
         <h3>Bug reports</h3>
         <a href="https://github.com/nim-lang/Nim/issues">
-          <i class="fa fa-github" aria-hidden="true"></i>
-          nim-lang/Nim
+          <i class="fa fa-github" aria-hidden="true"></i>nim-lang/Nim
         </a>
 
       </div>
@@ -235,8 +233,7 @@ echo("Average line length: ",
         <h3>Announcements</h3>
 
         <a href="https://twitter.com/nim_lang">
-          <i class="fa fa-twitter" aria-hidden="true"></i>
-          @nim_lang
+          <i class="fa fa-twitter" aria-hidden="true"></i>@nim_lang
         </a>
       </div>
       <div class="pure-u-1 center">


### PR DESCRIPTION
Eliminate spaces between icons and text, force one-line forum link, eliminate "https://" in the forum link.