### PR TITLE
Navigation improvements according to #47

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -31,14 +31,10 @@ navigation:
     url: /install.html
   - title: Documentation
     url: /documentation.html
-  - title: Community
-    url: /community.html
-  - title: Sponsors
-    url: /sponsors.html
+  - title: Forum
+    url: https://forum.nim-lang.org
   - title: Donate
     url: /donate.html
-  - title: FAQ
-    url: /faq.html
 
 # Build settings
 markdown: kramdown

--- a/jekyll/community.md
+++ b/jekyll/community.md
@@ -21,7 +21,8 @@ access it in multiple ways:
 
 <i class="fa fa-irc li" aria-hidden="true">#</i>
 Use an [IRC client](https://en.wikipedia.org/wiki/Internet_Relay_Chat#Clients)
-to connect to irc.freenode.net and join the #nim channel
+to connect to irc.freenode.net and join the #nim channel. You can also view
+the [IRC Logs](https://irclogs.nim-lang.org).
 
 <i class="fa fa-gitter black li" aria-hidden="true"></i>
 Join the Gitter chat room, which relays messages both ways between IRC and

--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -21,6 +21,10 @@ css_class: documentation
     <p>
       <a href="https://manning.com/books/nim-in-action?a_aid=niminaction&a_bid=78a27e81">Nim in Action</a>
     </p>
+    <h2 class="">Other</h2>
+    <p>
+      <a href="{{ site.baseurl }}/faq.html">Frequently Asked Questions</a>
+    </p>
     <h2 class="">Search Options</h2>
     <p>
       <i class="fa fa-search" aria-hidden="true"></i>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -210,7 +210,8 @@ echo("Average line length: ",
         <h2>IRC/Gitter</h2>
         <h3>Real-time chat</h3>
         <a href="irc://freenode.net/nim"><i class="fa fa-irc">#</i>FreeNode#nim</a><br/>
-        <a href="https://gitter.im/nim-lang/Nim"><i class="fa fa-gitter"></i>nim-lang/Nim</a>
+        <a href="https://gitter.im/nim-lang/Nim"><i class="fa fa-gitter"></i>nim-lang/Nim</a><br/>
+        <a href="https://irclogs.nim-lang.org"><i class="fa fa-irclogs">#</i>IRC Logs</a>
       </div>
       <div class="pure-u-1 pure-u-md-1-4">
         <h2>Forum</h2>


### PR DESCRIPTION
Cleanup navigation bar:
* Removed `community` (still available from the front page)
* Removed `sponsors` (still available from the front page)
* Removed `FAQ` (moved to `Documentation` page)

Improve forum reachability:
* Added `Forum` to navigation bar.

Mention IRC Logs:
* Added link to front page, near the IRC link
* Added link to `Community` page in the IRC paragraph
