### PR TITLE
Fix book blurb grammar.

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -136,8 +136,8 @@ echo("Average line length: ",
           The first Nim book, Nim in Action, is now available for purchase as
           an eBook or printed soft cover book.<span class="disclaimer">*</span>
           Learn the basics such as Nim's
-          syntax, advanced features including macros and gain practical
-          experience with the language by being lead through multiple
+          syntax and advanced features including macros, and gain practical
+          experience with the language by being led through multiple
           application development examples.
         </h2>
         <ul>
@@ -146,7 +146,7 @@ echo("Average line length: ",
           <li>
             Includes step-by-step instructions and explanations of
             how to develop various applications, including a chat program,
-            Twitter clone and more.
+            a Twitter clone and more.
           </li>
         </ul>
         <p class="disclaimer">


### PR DESCRIPTION
I first came upon Nim last year, and at least to me the grammar made the site look somewhat unserious.  It's not just the misspelling of `led`, but the wrong parallel construction ("learn X, Y, and gain").  So, I suggest this as a minimal rewrite to fix these.