### PR TITLE
Add community map

### DIFF
--- a/jekyll/_includes/map.html
+++ b/jekyll/_includes/map.html
@@ -1,0 +1,59 @@
+<section class="content map">
+  <h1 class="text-centered page-title main-heading">Users and contributors map</h1>
+  <div class="pure-g">
+
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 1em;
+      }
+
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+
+    </style>
+
+  </head>
+
+  <body>
+
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin="" />
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
+
+    <div id='map'> </div>
+
+    <script>
+      var map = L.map('map').setView([30.0, 0.0], 1.1);
+
+      L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+
+      // Nim users - dedicated branch on the GitHub website repository
+      let jurl = "https://raw.githubusercontent.com/nim-lang/community_map/community_map.json";
+
+      fetch(jurl)
+        .then(res => res.json())
+        .then((data) => {
+          data.items.forEach(function(i) {
+            L.circle([i.x, i.x], 10000, {
+              color: '#00d',
+              fillColor: '#00d',
+              fillOpacity: 0.5
+            }).addTo(map).bindPopup("Nick: " + i.nick);
+          });
+
+        });
+
+    </script>
+    <p>
+    Add your location to the map
+    <a href="https://github.com/nim-lang/community_map/edit/community_map.json">here</a>
+    Full name and email address are optional.
+    </p>
+  </div>
+</section>

--- a/jekyll/community.md
+++ b/jekyll/community.md
@@ -141,3 +141,6 @@ quickly, without needing to make pull requests.
 
 * [Nim wiki](https://github.com/nim-lang/Nim/wiki)
 
+# Users and contributors map
+
+{% include {{ map.html }} %}


### PR DESCRIPTION
A JSON file is fetched directly from a dedicated branch on GitHub as:
https://raw.githubusercontent.com/nim-lang/website/map/community_map.json

Example: https://screenshots.firefox.com/WEScqjpDIw38hejr/rawgit.com

This could help picking locations for future events.
