### PR TITLE
Fix Books section

### DIFF
--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -20,6 +20,8 @@ css_class: documentation
     <h2 class="">Books</h2>
     <p>
       <a href="https://book.picheta.me/">Nim in Action</a>
+    </p>
+    <p>
       <a href="https://xmonader.github.io/nimdays/index.html">Nim Days</a>
     </p>
     <h2 class="">Other</h2>


### PR DESCRIPTION
Right now on https://nim-lang.org/documentation.html the **Books** section looks like this:

## Books
[Nim in Action](https://book.picheta.me/) [Nim Days](https://xmonader.github.io/nimdays/index.html)
##

but this is now fixed and it looks like this now:


## Books
[Nim in Action](https://book.picheta.me/)
[Nim Days](https://xmonader.github.io/nimdays/index.html)
##