### PR TITLE
standardise feed.xml link #70

### DIFF
--- a/jekyll/blog.html
+++ b/jekyll/blog.html
@@ -35,5 +35,5 @@ title: Blog
     </div>
     <hr>
   {% endfor %}
-  <p class="feed-rss"><a href="{{ "/feed.xml" | prepend: site.baseurl }}">RSS feed</a></p>
+  <p class="feed-rss"><a href="{{ '/feed.xml' | prepend: site.baseurl }}">RSS feed</a></p>
 </section>

--- a/jekyll/community.md
+++ b/jekyll/community.md
@@ -79,7 +79,7 @@ If you are an avid RSS user then it should be just for you.
 [Nim blog]({{ site.baseurl }}/blog.html)
 
 <i class="fa fa-rss" aria-hidden="true"></i>
-[Blog feed]({{ site.baseurl }}/feed.xml)
+[Blog feed]({{ '/feed.xml' | prepend: site.baseurl }})
 
 # Reddit
 


### PR DESCRIPTION
It looks like feed.xml references were functioning.
This just standardises the few references to it.
Regardless of this merge issue (Make RSS links absolute #70) can be closed.