### PR TITLE
add link to Nimble

### DIFF
--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -62,7 +62,7 @@ css_class: documentation
     </p>
 
     <h3>
-        <a href="https://github.com/nim-lang/nimble">Nimble Package Manager</a>
+        <a href="https://github.com/nim-lang/nimble#readme">Nimble Package Manager</a>
     </h3>
     <p>
       Explains configuration and usage of Nimble package manager, including

--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -61,6 +61,14 @@ css_class: documentation
       The stylistic conventions that Nim's official projects adhere to.
     </p>
 
+    <h3>
+        <a href="https://github.com/nim-lang/nimble">Nimble Package Manager</a>
+    </h3>
+    <p>
+      Explains configuration and usage of Nimble package manager, including
+      creating and publishing your own packages.
+    </p>
+    
     <h3><a href="{{ site.baseurl }}/docs/nimc.html">Compiler User Guide</a></h3>
     <p>
       Outlines the commands and command line flags the Nim compiler supports.


### PR DESCRIPTION
There should be link to Nimble on the official site.

This closes [Nim issue #1749](https://github.com/nim-lang/Nim/issues/1749).