### PR TITLE
Added links to playground, package explorer and docker images

### DIFF
--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -34,6 +34,15 @@ css_class: documentation
     <p>
       <a href="https://github.com/nim-lang/Nim/wiki">Wiki</a>
     </p>
+    <p>
+      <a href="http://play.nim-lang.org/">Try Nim in your browser</a>
+    </p>
+    <p>
+      <a href="https://nimble.directory/">Package explorer (unofficial)</a>
+    </p>
+    <p>
+      <a href="https://github.com/moigagoo/nimage">Docker images (unofficial)</a>
+    </p>
     <h2 class="">Search Options</h2>
     <p>
       <i class="fa fa-search" aria-hidden="true"></i>


### PR DESCRIPTION
http://play.nim-lang.org/ is official, but I could not find it linked anywhere

https://nimble.directory/ and https://github.com/moigagoo/nimage are two common things that can be very useful for newcomers, even if they are unofficial