### PR TITLE
Add 'Learn' page

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -29,6 +29,8 @@ navigation:
     url: /features.html
   - title: Download
     url: /install.html
+  - title: Learn
+    url: /learn.html
   - title: Documentation
     url: /documentation.html
   - title: Forum

--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -84,6 +84,15 @@ css_class: documentation
       Read this if you want to hack the compiler.
     </p>
 
+    <h2 class="">Search Options</h2>
+    <h3>
+      <i class="fa fa-search" aria-hidden="true"></i>
+      <a href="{{ site.baseurl }}/docs/theindex.html">Searchable index</a>
+    </h3>
+    <p>
+      All Nim documents and modules in one place. Use Ctrl/Cmd+F.
+    </p>
+
     <h2 class="">Other</h2>
     <p>
       <a href="{{ site.baseurl }}/faq.html">Frequently Asked Questions</a>
@@ -91,11 +100,11 @@ css_class: documentation
     <p>
       <a href="https://github.com/nim-lang/Nim/wiki">Wiki</a>
     </p>
-    <h2 class="">Search Options</h2>
     <p>
-      <i class="fa fa-search" aria-hidden="true"></i>
-      <a href="{{ site.baseurl }}/docs/theindex.html">Searchable index</a>
-      (Use Ctrl/Cmd+F)
+      <a href="https://nimble.directory/">Nimble Package Directory</a>
+    </p>
+    <p>
+      <a href="https://github.com/moigagoo/nimage">Docker images (unofficial)</a>
     </p>
   </div>
 </section>

--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -5,42 +5,6 @@ css_class: documentation
 ---
 <section class="pure-g content">
   <h1 class="pure-u-1 text-centered page-title main-heading">{{page.title}}</h1>
-  <div class="pure-u-1 pure-u-md-1-2">
-    <h2 class="">Tutorials</h2>
-    <p>
-      <a href="{{ site.baseurl }}/docs/tut1.html">Official tutorial</a>
-    </p>
-    <p>
-      <a href="https://narimiran.github.io/nim-basics/">Nim basics</a>
-    </p>
-    <p>
-      <a href="http://howistart.org/posts/nim/1/index.html">How I Start: Nim</a>
-    </p>
-    <p>
-      <a href="https://nim-by-example.github.io/getting_started/">Nim by Example</a>
-    </p>
-
-    <h2 class="">Books</h2>
-    <p>
-      <a href="https://book.picheta.me/">Nim in Action</a>
-    </p>
-    <p>
-      <a href="https://xmonader.github.io/nimdays/index.html">Nim Days</a>
-    </p>
-    <h2 class="">Other</h2>
-    <p>
-      <a href="{{ site.baseurl }}/faq.html">Frequently Asked Questions</a>
-    </p>
-    <p>
-      <a href="https://github.com/nim-lang/Nim/wiki">Wiki</a>
-    </p>
-    <h2 class="">Search Options</h2>
-    <p>
-      <i class="fa fa-search" aria-hidden="true"></i>
-      <a href="{{ site.baseurl }}/docs/theindex.html">Searchable index</a>
-      (Use Ctrl/Cmd+F)
-    </p>
-  </div>
 
   <div class="pure-u-1 pure-u-md-1-2">
     <h2 class="">Standards &amp; Guides</h2>
@@ -62,13 +26,13 @@ css_class: documentation
     </p>
 
     <h3>
-        <a href="https://github.com/nim-lang/nimble#readme">Nimble Package Manager</a>
+      <a href="https://github.com/nim-lang/nimble#readme">Nimble Package Manager</a>
     </h3>
     <p>
       Explains configuration and usage of Nimble package manager, including
       creating and publishing your own packages.
     </p>
-    
+
     <h3><a href="{{ site.baseurl }}/docs/nimc.html">Compiler User Guide</a></h3>
     <p>
       Outlines the commands and command line flags the Nim compiler supports.
@@ -89,8 +53,6 @@ css_class: documentation
       languages.
     </p>
 
-    <hr/>
-
     <h3><a href="https://nim-lang.github.io/Nim/">Bleeding Edge Docs</a></h3>
     <p>
        Latest docs built from the Nim <code>devel</code> branch. Rebuilt on
@@ -109,11 +71,9 @@ css_class: documentation
     <p>
       Description of some tools that come with the standard distribution.
     </p>
-  </div>
 
-  <div class="pure-u-1 pure-u-md-1-2">
     <h2 class="">Internal Details</h2>
-    <p><a href="{{ site.baseurl }}/docs/gc.html">Garbage Collector</a></h3>
+    <h3><a href="{{ site.baseurl }}/docs/gc.html">Garbage Collector</a></h3>
     <p>
       Additional documentation about Nim's GC and how to operate it in a
       realtime setting.
@@ -122,6 +82,20 @@ css_class: documentation
     <p>
       The internal documentation describes how the compiler is implemented.
       Read this if you want to hack the compiler.
+    </p>
+
+    <h2 class="">Other</h2>
+    <p>
+      <a href="{{ site.baseurl }}/faq.html">Frequently Asked Questions</a>
+    </p>
+    <p>
+      <a href="https://github.com/nim-lang/Nim/wiki">Wiki</a>
+    </p>
+    <h2 class="">Search Options</h2>
+    <p>
+      <i class="fa fa-search" aria-hidden="true"></i>
+      <a href="{{ site.baseurl }}/docs/theindex.html">Searchable index</a>
+      (Use Ctrl/Cmd+F)
     </p>
   </div>
 </section>

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -8,7 +8,11 @@ title: Nim programming language
     <div class="pure-g">
       <div class="pure-u-1 pure-u-md-3-5 main-block">
         <h1>Efficient and expressive programming.</h1>
-        <h2>Nim is a systems and applications programming language. Statically typed and compiled, it provides unparalleled performance in an elegant package.</h2>
+        <h2>
+            Nim is a systems and applications programming language.
+            Statically typed and compiled, it provides unparalleled performance
+            in an elegant package.
+        </h2>
         <ul>
           <li>High-performance garbage-collected language</li>
           <li>Compiles to C, C++ or JavaScript</li>
@@ -67,10 +71,8 @@ echo("Average line length: ",
 
 <section class="background-faded call-to-action feature-projects">
   <section class="content">
-    <h2 class="text-centered">Featured projects</h2>
-
+    <h1 class="text-centered">Featured projects</h1>
     <div class="pure-g center">
-
       <div class="pure-u-1-1 pure-u-md-1-3">
         <div class="project-container">
           <h2>
@@ -109,20 +111,19 @@ echo("Average line length: ",
 
 <section class="content center-banner">
   <h1 class="section-heading">
-    <i class="fab fa-github fa-2x" aria-hidden="true"></i>
-    Looking for the GitHub repository?
+    <i class="fa fa-graduation-cap fa-2x" aria-hidden="true"></i>
+    Learn Nim today
   </h1>
   <div class="pure-g center">
     <div class="pure-u-1-2">
       <p>
-        The Nim compiler and tools are all written in Nim and licensed under the
-        MIT license, with most development taking place on GitHub.
-        Be sure to watch the repository to get updates on Nim's
-        development, or star it to give us some brownie points.
+        Build command-line applications, games, web servers, kernels and everything
+        else in between. Nim has a low barrier to entry and offers powerful
+        features you won't find in many mainstream programming languages.
       </p>
     </div>
     <div class="pure-u-1 center">
-      <a class="pure-button" href="https://github.com/nim-lang/Nim">Source code</a>
+      <a class="pure-button" href="{{ site.baseurl }}/learn.html">Get started now</a>
     </div>
   </div>
 </section>
@@ -252,19 +253,20 @@ echo("Average line length: ",
 
 <section class="content center-banner">
   <h1 class="section-heading">
-    <i class="fa fa-graduation-cap fa-2x" aria-hidden="true"></i>
-    Learn Nim today
+    <i class="fab fa-github fa-2x" aria-hidden="true"></i>
+    Looking for the GitHub repository?
   </h1>
   <div class="pure-g center">
     <div class="pure-u-1-2">
       <p>
-        Build command-line applications, games, web servers, kernels and everything
-        else in between. Nim has a low barrier to entry and offers powerful
-        features you won't find in many mainstream programming languages.
+        The Nim compiler and tools are all written in Nim and licensed under the
+        MIT license, with most development taking place on GitHub.
+        Be sure to watch the repository to get updates on Nim's
+        development, or star it to give us some brownie points.
       </p>
     </div>
     <div class="pure-u-1 center">
-      <a class="pure-button" href="{{ site.baseurl }}/docs/tut1.html">Get started now</a>
+      <a class="pure-button" href="https://github.com/nim-lang/Nim">Source code</a>
     </div>
   </div>
 </section>

--- a/jekyll/learn.html
+++ b/jekyll/learn.html
@@ -56,6 +56,10 @@ css_class: documentation
     <p>
       The stylistic conventions that Nim's official projects adhere to.
     </p>
+    <h3><a href="https://nimble.directory/">Nimble Package Directory</a></h3>
+    <p>
+      Search for available Nimble packages.
+    </p>
   </div>
 
 

--- a/jekyll/learn.html
+++ b/jekyll/learn.html
@@ -1,0 +1,133 @@
+---
+title: "Learn Nim"
+layout: page
+css_class: documentation
+---
+<section class="pure-g content">
+  <h1 class="pure-u-1 text-centered page-title main-heading">{{page.title}}</h1>
+  <div class="pure-u-1 pure-u-md-1-2">
+    <h1 class="">Official Resources</h1>
+
+    <h2 class="">Tutorials</h2>
+    <h3><a href="{{ site.baseurl }}/docs/tut1.html">Tutorial, part 1</a></h3>
+    <p>
+      A guide about basic and advanced built-in types, statements, control flow,
+      and procedures.
+    </p>
+    <h3><a href="{{ site.baseurl }}/docs/tut2.html">Tutorial, part 2</a></h3>
+    <p>
+      How to use Object Oriented Programming in Nim, exceptions,
+      generics, and templates.
+    </p>
+    <h3><a href="{{ site.baseurl }}/docs/tut3.html">Macro tutorial</a></h3>
+    <p>
+      Learn about metaprogramming and macros.
+    </p>
+
+    <h2 class="">Books</h2>
+    <h3><a href="https://book.picheta.me/">Nim in Action</a></h3>
+    <p>
+      Learn Nim from one of the main developers of the language.
+      A tour through the standard library, a guide on writing your own packages
+      and applications, interfacing with C and JavaScript, and much more.
+    </p>
+
+    <h2 class="">Playground</h2>
+    <h3><a href="https://play.nim-lang.org/">Nim Playground</a></h3>
+    <p>
+      Compile and run Nim snippets in your browser.
+    </p>
+
+    <h2 class="">Documentation</h2>
+    <h3><a href="{{ site.baseurl }}/docs/lib.html">Standard Library</a></h3>
+    <p>
+      Provides a listing and description of all the modules in the standard
+      library.
+    </p>
+    <h3><a href="{{ site.baseurl }}/docs/manual.html">Language Manual</a></h3>
+    <p>
+      The Nim programming language specification.
+    </p>
+    <h3><a href="{{ site.baseurl }}/docs/theindex.html">Searchable index</a></h3>
+    <p>
+      All Nim documents and modules in one place. Use Ctrl/Cmd+F.
+    </p>
+    <h3><a href="{{ site.baseurl }}/docs/nep1.html">Nim Style Guide</a></h3>
+    <p>
+      The stylistic conventions that Nim's official projects adhere to.
+    </p>
+  </div>
+
+
+  <div class="pure-u-1 pure-u-md-1-2">
+    <h1 class="">Community resources</h1>
+    <h2 class="">Tutorials</h2>
+    <h3>
+      <a href="https://narimiran.github.io/nim-basics/">Nim basics</a>
+    </h3>
+    <p>
+      For programming beginners. Covers all the basic topics, enough to make
+      your first programming steps.
+    </p>
+    <h3>
+      <a href="http://howistart.org/posts/nim/1/index.html">How I Start: Nim</a>
+    </h3>
+    <p>
+      Write an interpreter for Brainfuck programming language in Nim.
+    </p>
+    <h3>
+      <a href="https://nim-by-example.github.io/getting_started/">Nim by Example</a>
+    </h3>
+    <p>
+      A series of short examples covering the most common topics.
+    </p>
+    <h3>
+      <a href="https://xmonader.github.io/nimdays/">Nim Days</a>
+    </h3>
+    <p>
+      Building mini applications with Nim.
+    </p>
+    <h3>
+      <a href="https://learnxinyminutes.com/docs/nim/">Learn Nim in Y minutes</a>
+    </h3>
+    <p>
+      A 5-minute tour through Nim.
+    </p>
+
+    &nbsp;
+    <h2 class="">Nim for...</h2>
+    <h3>
+      <a href="https://github.com/nim-lang/Nim/wiki/Nim-for-C-programmers">
+        ... C programmers
+      </a>
+    </h3>
+    <h3>
+      <a href="https://github.com/nim-lang/Nim/wiki/Nim-for-Python-Programmers">
+        ... Python programmers
+      </a>
+    </h3>
+
+    <h2 class="">Blogs</h2>
+    <h3>
+        <a href="http://goran.krampe.se/category/nim/">Goran Krampe</a>
+    </h3>
+    <p>
+      OOP in Nim, Arduino and Nim, and more.
+    </p>
+    <h3>
+        <a href="https://hookrace.net/blog/nim/">HookRace</a>
+    </h3>
+    <p>
+      NES emulator in Nim, SDL2 platformer, writing small binaries, etc.
+    </p>
+
+    <h2 class="">Code challenges</h2>
+    <h3>
+        <a href="https://exercism.io/my/tracks/nim">Exercism.io</a>
+    </h3>
+    <p>
+      Learn Nim by solving short challenges.
+    </p>
+  </div>
+
+</section>


### PR DESCRIPTION
This PR adds a new 'Learn' page with useful official and community resources for learning Nim. Fixes #135.

This means that 'Documentation' is also slightly reworked (tutorials and books are removed, see the screenshots below).  
There is a new button 'Learn' on the header on the top of the pages.

New 'Learn' page:
![Learn1](https://i.imgur.com/FncWeRi.png)
![Learn2](https://i.imgur.com/MFNYWEO.png)

Reworked 'Documentation' page (old on the left, new on the right):
![Documentation](https://i.imgur.com/a8dY9IE.png)

"Learn Nim today" section moved up on the main (index.html) page, and now the button takes you to the new 'Learn' page:
![Learn section](https://i.imgur.com/iQQbggr.png)

----

Some of the things are duplicated in 'Documentation' and 'Learn', and that is intentional!  
When you're learning Nim, some of the documentation and style guide is useful to you. Also, when you're experienced and you need to revisit some documentation, you have everything in one place under 'Documentation'.

This was already internally approved — I'm not merging yet if there are typos and some details that need more polishing.