### PR TITLE
link the latest stdlib documentation

### DIFF
--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -9,7 +9,7 @@ css_class: documentation
   <div class="pure-u-1 pure-u-md-1-2">
     <h2 class="">Standards &amp; Guides</h2>
 
-    <h3><a href="{{ site.baseurl }}/docs/lib.html">Standard Library</a></h3>
+    <h3><a href="https://nim-lang.github.io/Nim/lib.html">Standard Library</a></h3>
     <p>
       Provides a listing and description of all the modules in the standard
       library.


### PR DESCRIPTION
As discussed with @Araq, since the documentation stuff is not backported, we should link to the latest version of stdlib documentation, containing all the improvements. At least until v0.20 is out.