### PR TITLE
Correction on the compilation to avoid ambiguity

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -15,7 +15,7 @@ title: Nim programming language
         </h2>
         <ul>
           <li>High-performance garbage-collected language</li>
-          <li>Compiles to C, C++ or JavaScript</li>
+          <li>Compile in binary or transpile to Javacript</li>
           <li>Produces dependency-free binaries</li>
           <li>Runs on Windows, macOS, Linux, and more</li>
         </ul>


### PR DESCRIPTION
Hello,

I made this sentence change because in all the development communities I know, people thought that Nim was transposing into C a bit like Typescript for Javascript

So I think it is more appropriate to explain that Nim compiles in binary or transposes in Javascript as desired