### PR TITLE
Don't affix navigation bar at the top of the screen on desktop.

### DIFF
--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -146,7 +146,6 @@ footer {
   padding: 0;
   z-index: 100;
   line-height: 1;
-  position: fixed;
   background-color: $menu-background-color;
 
   a {


### PR DESCRIPTION
Nothing grinds my gears more than seeing the nav bar stickied to the top of my browser window. Hope you will agree with me here, this is already stickied on mobile and doesn't need to be stickied on desktop.