### PR TITLE
Explain what a variant means in other languages

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -39,7 +39,7 @@ use_dark_highlighting: true
         <ul>
           <li>Macros cannot change Nim's syntax because there is no need for it —
               the syntax is flexible enough.</li>
-          <li>Modern type system with local type inference, tuples, generics and variants (also called sum types, tagged unions or algebraic data types)</li>
+          <li>Modern type system with local type inference, tuples, generics and sum types.</li>
           <li>Statements are grouped by indentation but can span multiple lines.</li>
         </ul>
 

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -39,7 +39,7 @@ use_dark_highlighting: true
         <ul>
           <li>Macros cannot change Nim's syntax because there is no need for it —
               the syntax is flexible enough.</li>
-          <li>Modern type system with local type inference, tuples, variants, generics, etc.</li>
+          <li>Modern type system with local type inference, tuples, generics and variants (also called sum types or algebraic data types)</li>
           <li>Statements are grouped by indentation but can span multiple lines.</li>
         </ul>
 

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -39,7 +39,7 @@ use_dark_highlighting: true
         <ul>
           <li>Macros cannot change Nim's syntax because there is no need for it —
               the syntax is flexible enough.</li>
-          <li>Modern type system with local type inference, tuples, generics and variants (also called sum types or algebraic data types)</li>
+          <li>Modern type system with local type inference, tuples, generics and variants (also called sum types, tagged unions or algebraic data types)</li>
           <li>Statements are grouped by indentation but can span multiple lines.</li>
         </ul>
 


### PR DESCRIPTION
People from a functional background are more familiar with the sum type or ADT terminology.

Also removed the `etc`. AFAIK it only hides `concepts` which are still experimental.