### PR TITLE
Fix several typos and improve grammar

### DIFF
--- a/jekyll/_posts/2009-12-21-version-086-released.md
+++ b/jekyll/_posts/2009-12-21-version-086-released.md
@@ -25,7 +25,7 @@ Additions
 - Added ``system.contains`` for open arrays.
 - The PEG module now supports the *search loop operator* ``@``.
 - Grammar/parser: ``SAD|IND`` is allowed before any kind of closing bracket.
-  This allows for more flexible source code formating.
+  This allows for more flexible source code formatting.
 - The compiler now uses a *bind* table for symbol lookup within a ``bind``
   context. (See [manual.html#templates](https://nim-lang.org/docs/manual.html#templates) for details.)
 - ``discard """my long comment"""`` is now optimized away.

--- a/jekyll/_posts/2012-09-23-version-090-released.md
+++ b/jekyll/_posts/2012-09-23-version-090-released.md
@@ -91,7 +91,7 @@ Changes affecting backwards compatibility
   to ``pegs.!*\`` as ``@`` operators now have different precedence.
 - The type ``proc`` (without any params or return type) is now considered a
   type class matching all proc types. Use ``proc ()`` to get the old meaning
-  denoting a proc expecing no arguments and returing no value.
+  denoting a proc expecing no arguments and returning no value.
 - Deprecated ``system.GC_setStrategy``.
 - ``re.findAll`` and ``pegs.findAll`` don't return *captures* anymore but
   matching *substrings*.

--- a/jekyll/_posts/2015-04-30-version-0110-released.md
+++ b/jekyll/_posts/2015-04-30-version-0110-released.md
@@ -365,7 +365,7 @@ Bugfixes
   ([#2247](https://github.com/Araq/Nim/issues/2247))
 - Fixed "Two different type names generated for a single type (C backend)"
   ([#2250](https://github.com/Araq/Nim/issues/2250))
-- Fixed "Ambigous call when it should not be"
+- Fixed "Ambiguous call when it should not be"
   ([#2229](https://github.com/Araq/Nim/issues/2229))
 - Fixed "Make sure we can load root urls"
   ([#2227](https://github.com/Araq/Nim/issues/2227))

--- a/jekyll/_posts/2016-09-03-community-survey-results-2016.md
+++ b/jekyll/_posts/2016-09-03-community-survey-results-2016.md
@@ -34,7 +34,7 @@ With these general facts in mind, let's begin looking at specific questions.
 
 The rationale for the first question was simple, we wanted to know where our
 respondents found out about Nim. This is an interesting question for us, as
-we do occassionally get users asking us why it took so long for them to hear
+we do occasionally get users asking us why it took so long for them to hear
 about Nim. It allows us to see how effective each website is at spreading the
 word about Nim.
 

--- a/jekyll/_posts/2017-05-17-version-0170-released.md
+++ b/jekyll/_posts/2017-05-17-version-0170-released.md
@@ -65,7 +65,7 @@ for a list of changes since its last release.
   to ``sa_sigaction*: proc (x: cint, y: ptr SigInfo, z: pointer) {.noconv.}``.
 - The compiler doesn't infer effects for ``.base`` methods anymore. This means
   you need to annotate them with ``.gcsafe`` or similar to clearly declare
-  upfront every implementation needs to fullfill these contracts.
+  upfront every implementation needs to fulfill these contracts.
 - ``system.getAst templateCall(x, y)`` now typechecks the ``templateCall``
   properly. You need to patch your code accordingly.
 - ``macros.getType`` and ``macros.getTypeImpl`` for an enum will now return an
@@ -85,7 +85,7 @@ for a list of changes since its last release.
   of Nim will also require you to initialize all the fields of the type during
   object construction. For now, only a warning will be produced.
 - The Object construction syntax now performs a number of additional safety
-  checks. When fields within case objects are initialiazed, the compiler will
+  checks. When fields within case objects are initialized, the compiler will
   now demand that the respective discriminator field has a matching known
   compile-time value.
 - On posix, the results of `waitForExit`, `peekExitCode`, `execCmd` will return

--- a/jekyll/_posts/2017-10-01-community-survey-results-2017.md
+++ b/jekyll/_posts/2017-10-01-community-survey-results-2017.md
@@ -140,8 +140,8 @@ simply provide a summary:
 * Linux is still the most popular development platform, with Windows second and
   macOS third.
 * The same is true for the target platform. But in addition to this, a large
-  19% of respondents are targetting Android, 16.7% are targetting JavaScript,
-  10.5% are targetting iOS and 10.1% are targetting embedded platforms.
+  19% of respondents are targeting Android, 16.7% are targeting JavaScript,
+  10.5% are targeting iOS and 10.1% are targeting embedded platforms.
 * The current release of Nim (0.17.0) is the most used at 68.8%, with Git HEAD
   second at 33.1%.
 * 52.2% of respondent's code was never broken by a Nim upgrade.

--- a/jekyll/_posts/2018-01-22-yes-command-in-nim.md
+++ b/jekyll/_posts/2018-01-22-yes-command-in-nim.md
@@ -85,7 +85,7 @@ $ ./yes | pv > /dev/null
 ... [7.16GiB/s] ...
 ```
 
-That's it! Nim has succesfully achieved the same efficiency as the `yes` written in native C.
+That's it! Nim has successfully achieved the same efficiency as the `yes` written in native C.
 
 Although we managed to match the write speed, we also made our code less expressive. Luckily this is Nim, so a simple template will help cleaning this up while keeping the performance unimpacted!
 

--- a/jekyll/_posts/2018-03-01-version-0180-released.md
+++ b/jekyll/_posts/2018-03-01-version-0180-released.md
@@ -288,7 +288,7 @@ without you!
 
 - We changed how array accesses "from backwards" like ``a[^1]`` or ``a[0..^1]`` are
   implemented. These are now implemented purely in ``system.nim`` without compiler
-  support. There is a new "heterogenous" slice type ``system.HSlice`` that takes 2
+  support. There is a new "heterogeneous" slice type ``system.HSlice`` that takes 2
   generic parameters which can be ``BackwardsIndex`` indices. ``BackwardsIndex`` is
   produced by ``system.^``.
   This means if you overload ``[]`` or ``[]=`` you need to ensure they also work

--- a/jekyll/_posts/2018-06-07-create-a-simple-macro.md
+++ b/jekyll/_posts/2018-06-07-create-a-simple-macro.md
@@ -102,7 +102,7 @@ macro edges(head, body: untyped): untyped =
     # we look to implement.
     if n.kind == nnkInfix and $n[0] == "->":
       # we pass the template to getAst to avoid constructing
-      # the AST manualy
+      # the AST manually
       result.add getAst(adder(head, n[1], n[2]))
 ```
 

--- a/jekyll/_posts/2018-09-11-nim-is-hiring.md
+++ b/jekyll/_posts/2018-09-11-nim-is-hiring.md
@@ -42,10 +42,10 @@ development, meta programming and language design. Here are our requirements:
   We are not just looking for programmers, Nim's specification also needs to
   be improved and extended.
 - Experience in IDE development, there is no reason Nim's tooling can't rival
-  the state of the art when it comes to error messages, auto-completion and
+  the state-of-the-art when it comes to error messages, auto-completion and
   automatic refactorings.
 
-Note that you don't have to fullfill *every* one of these criteria; Nim is a
+Note that you don't have to fulfill *every* one of these criteria; Nim is a
 large project with plenty of work covering diverse topics and our requirements
 reflect this.
 

--- a/jekyll/community.md
+++ b/jekyll/community.md
@@ -33,11 +33,11 @@ Join the Discord chat room, which relays messages both ways between IRC and
 Discord, by clicking [here](https://discord.gg/ezDFDw2).
 
 <i class="fab black li" aria-hidden="true">m</i>
-Join the Matrix chat room, which relays messages both ways between IRC and 
+Join the Matrix chat room, which relays messages both ways between IRC and
 Matrix, by clicking [here](https://matrix.to/#/#freenode_#nim:matrix.org).
 
 <i class="fab fa-telegram black li" aria-hidden="true"></i>
-Join the Telegram chat room (it doesn't relay any messages) 
+Join the Telegram chat room (it doesn't relay any messages)
 by clicking [here](https://t.me/nim_lang).
 
 You can join this chat room to ask a quick question, or engage in a discussion
@@ -83,7 +83,7 @@ If you are an avid RSS user then it should be just for you.
 
 # Reddit
 
-The Nim subreddit contains many user submitted announcements, blog posts,
+The Nim subreddit contains many user-submitted announcements, blog posts,
 discussions. It is a good place to share your work with the Nim community and
 to get updates about the project so be sure to hit that subscribe button.
 
@@ -131,8 +131,8 @@ If you have found an issue in the compiler, the standard library or any of
 the tools then please create an issue in the relevant repository. If
 appropriate include a minimal example reproducing the issue.
 
-If you have a feature request then consider creating a formal RFC
-(Request for comments). In it you should describe the feature clearly,
+If you have a feature request, then consider creating a formal RFC
+(Request For Comments). In it you should describe the feature clearly,
 including the use cases that you foresee for the feature and anything else
 that you think is relevant. RFCs are currently submitted to the
 issue tracker.
@@ -141,10 +141,10 @@ issue tracker.
 
 A good place for general user-submitted articles and content. For instance,
 things like random howtos, tutorials, notes, links to interesting content,
-and so on. Also a good place to post material or ideas that come up during
-forum or IRC chats, for instance.
+and so on. It's also a good place to post material or ideas that come up
+during forum or IRC chats, for instance.
 
-It's hosted on github, but also very easy for anyone to edit and share
+It's hosted on GitHub, but also very easy for anyone to edit and share
 quickly, without needing to make pull requests.
 
 * [Nim wiki](https://github.com/nim-lang/Nim/wiki)

--- a/jekyll/donate.md
+++ b/jekyll/donate.md
@@ -45,13 +45,13 @@ EU VAT-IN: DE297783450<br/>
 
 ## Priority bug fixes
 
-File a bug report and we will address them with the highest priority.
+File a bug report; we will address it with the highest priority.
 Once fixed, you will be able to access either the current Git build or
 at your request a custom build against the latest release with your bug fixed.
 
 ## Feature requests
 
-Suggest to us any feature that you might need, we will examine your request
+Suggest to us any feature that you might need. We will examine your request
 with care and provide a proper answer about its potential for inclusion.
 
 Communication happens via email or for a slightly higher fee via Skype.
@@ -60,7 +60,7 @@ implementation and is open to negotiation.
 
 # Other ways to donate
 
-Apart from BountySource you can also donate to Nim using one the following
+Apart from BountySource, you can also donate to Nim using one the following
 services.
 
 

--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -11,7 +11,7 @@ css_class: faq
 ## Why yet another programming language?
 
 Nim is one of the very few _programmable_ statically typed languages, and
-combines the speed and memory efficency of C, an expressive syntax,
+combines the speed and memory efficiency of C, an expressive syntax,
 memory safety and multiple target languages.
 
 ## How stable is Nim?

--- a/jekyll/features.html
+++ b/jekyll/features.html
@@ -102,7 +102,7 @@ for person in people:
           </div>
         </div>
         <div class="pure-u-1 pure-u-md-1-2">
-          <h2 id="native-performance-with-optimisations">Native performance with state of the art optimisations</h2>
+          <h2 id="native-performance-with-optimisations">Native performance with state-of-the-art optimisations</h2>
           <p>
           By compiling to C, Nim is able to take advantage of many
           features offered by modern C compilers. The primary benefits
@@ -365,4 +365,3 @@ Error: unhandled exception:
       </h2>
     </section>
   </section>
-

--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -21,9 +21,9 @@ use_dark_highlighting: true
           <li>Nim generates native dependency-free executables, not dependent on a virtual machine,
               which are small and allow easy redistribution.</li>
           <li>The Nim compiler and the generated executables support all major platforms like
-              Windows, Linux, BSD and Mac OS X.</li>
+              Windows, Linux, BSD and macOS.</li>
           <li>Fast deferred reference counting memory management that supports real-time systems.</li>
-          <li>Modern concepts like zero-overhead iterators and compile time evaluation
+          <li>Modern concepts like zero-overhead iterators and compile-time evaluation
               of user-defined functions, in combination with the preference of value-based
               datatypes allocated on the stack, lead to extremely performant code.</li>
           <li>Support for various backends: it compiles to C, C++ or JavaScript so that Nim
@@ -31,7 +31,7 @@ use_dark_highlighting: true
         </ul>
         <h3>Expressive</h3>
         <ul>
-          <li>Nim is self contained: the compiler and all of the standard library are implemented in Nim.</li>
+          <li>Nim is self-contained: the compiler and the standard library are implemented in Nim.</li>
           <li>Nim has a powerful macro system which allows direct manipulation of the AST,
               offering nearly unlimited opportunities.</li>
         </ul>
@@ -56,7 +56,7 @@ import strformat
 type
   Person = object
     name: string
-    age: Natural # ensures the age is positive
+    age: Natural # Ensures the age is positive
 
 let people = [
   Person(name: "John", age: 45),


### PR DESCRIPTION
Found using `codespell -wi3 **/*.{html,md}` and [LanguageTool](https://languagetool.org/).