### PR TITLE
Add snap package to Linux/UNIX instructions

### DIFF
--- a/jekyll/install_unix.md
+++ b/jekyll/install_unix.md
@@ -177,6 +177,12 @@ brew install nim
 zypper in nim
 ```
 
+## Snap
+
+```
+snap install nim-lang
+```
+
 ## Void Linux
 
 ```


### PR DESCRIPTION
I am maintaining snaps of Nim, including stable, LTS 1.0.x, and nightly builds.

I am continuously building and pushing the snaps on GitHub Actions:
https://github.com/sirredbeard/nim_lang_snap

I propose including the snap instructions in the official documentation for installing on Linux.

Snapcraft Store listings:
https://snapcraft.io/nim-lang
https://snapcraft.io/nim-lang-nightly
https://snapcraft.io/nim-lang-lts-1