### PR TITLE
Fix snap install and added LTS and nightly options

### DIFF
--- a/jekyll/install_unix.md
+++ b/jekyll/install_unix.md
@@ -179,9 +179,24 @@ zypper in nim
 
 ## Snap
 
+Get the latest stable release:
+
 ```
-snap install nim-lang
+snap install nim-lang --classic
 ```
+
+Get the latest LTS 1.0.x release:
+
+```
+snap install nim-lang-lts-1 --classic
+```
+
+Get the latest nightly build:
+
+```
+snap install nim-lang-nightly --classic
+```
+
 
 ## Void Linux
 


### PR DESCRIPTION
After working with snap team it has been determined that snap functions best in classic, not strict, snap confinement.

This will enable the nim snap to compile to C++ and JavaScript and use compilers other than gcc.

I have updated the snap YAML and tested it.

I am just waiting on the classic snap to be approved for the store.

I have also added LTS and nightly options.