### PR TITLE
use_dark_highlighting in posts if has code block

### DIFF
--- a/jekyll/_posts/2009-12-21-version-086-released.md
+++ b/jekyll/_posts/2009-12-21-version-086-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.8.6 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 The version jump from 0.8.2 to 0.8.6 acknowledges the fact that all development

--- a/jekyll/_posts/2010-03-14-version-088-released.md
+++ b/jekyll/_posts/2010-03-14-version-088-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.8.8 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 Bugfixes

--- a/jekyll/_posts/2010-10-20-version-0810-released.md
+++ b/jekyll/_posts/2010-10-20-version-0810-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.8.10 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 Bugfixes

--- a/jekyll/_posts/2011-07-10-version-0812-released.md
+++ b/jekyll/_posts/2011-07-10-version-0812-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.8.12 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 Bugfixes

--- a/jekyll/_posts/2012-02-09-version-0814-released.md
+++ b/jekyll/_posts/2012-02-09-version-0814-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.8.14 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 Version 0.8.14 has been released!

--- a/jekyll/_posts/2012-09-23-version-090-released.md
+++ b/jekyll/_posts/2012-09-23-version-090-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.9.0 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 Summary

--- a/jekyll/_posts/2013-05-20-version-092-released.md
+++ b/jekyll/_posts/2013-05-20-version-092-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.9.2 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We are pleased to announce that version 0.9.2 of the Nimrod compiler has been

--- a/jekyll/_posts/2014-01-12-andreas-rumpfs-talk.md
+++ b/jekyll/_posts/2014-01-12-andreas-rumpfs-talk.md
@@ -1,6 +1,7 @@
 ---
 title: "Andreas Rumpf's talk on Nimrod at Strange Loop 2013 is now online"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 Andreas Rumpf presented *Nimrod: A New Approach to Metaprogramming* at

--- a/jekyll/_posts/2014-02-11-nimrod-features-in-dr-dobbs-journal.md
+++ b/jekyll/_posts/2014-02-11-nimrod-features-in-dr-dobbs-journal.md
@@ -1,6 +1,7 @@
 ---
 title: "Nimrod Featured in Dr. Dobb's Journal"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 

--- a/jekyll/_posts/2014-04-21-version-094-released.md
+++ b/jekyll/_posts/2014-04-21-version-094-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.9.4 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 The Nimrod development community is proud to announce the release of version

--- a/jekyll/_posts/2014-10-19-version-096-released.md
+++ b/jekyll/_posts/2014-10-19-version-096-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.9.6 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 **Note: 0.9.6 is the last release of Nimrod. The language is being renamed to

--- a/jekyll/_posts/2014-12-09-new-website.md
+++ b/jekyll/_posts/2014-12-09-new-website.md
@@ -1,6 +1,7 @@
 ---
 title: "New website design!"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 A brand new website including an improved forum is now live.

--- a/jekyll/_posts/2014-12-29-version-0102-released.md
+++ b/jekyll/_posts/2014-12-29-version-0102-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.10.2 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 This release marks the completion of a very important change to the project:

--- a/jekyll/_posts/2015-04-30-version-0110-released.md
+++ b/jekyll/_posts/2015-04-30-version-0110-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.11.0 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 With this release we are one step closer to reaching version 1.0 and by

--- a/jekyll/_posts/2015-05-04-version-0112-released.md
+++ b/jekyll/_posts/2015-05-04-version-0112-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.11.2 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 This is just a bugfix release that fixes the most pressing regressions we

--- a/jekyll/_posts/2015-10-16-first-nim-conference.md
+++ b/jekyll/_posts/2015-10-16-first-nim-conference.md
@@ -2,6 +2,7 @@
 title: "First Nim conference"
 excerpt: "Learn about the first Nim workshop in Kyiv."
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 <div class="center">

--- a/jekyll/_posts/2015-10-27-version-0120-released.md
+++ b/jekyll/_posts/2015-10-27-version-0120-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.12.0 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 The Nim community of developers is proud to announce the new version of the

--- a/jekyll/_posts/2016-01-18-oscon-conf-amsterdam.md
+++ b/jekyll/_posts/2016-01-18-oscon-conf-amsterdam.md
@@ -1,6 +1,7 @@
 ---
 title: "Andreas Rumpf's talk at OSCON Amsterdam"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 In case you have missed it, here is Andreas' Nim: An Overview talk at

--- a/jekyll/_posts/2016-01-18-version-0130-released.md
+++ b/jekyll/_posts/2016-01-18-version-0130-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.13.0 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 Once again we are proud to announce the latest release of the Nim compiler

--- a/jekyll/_posts/2016-01-27-nim-in-action-now-available.md
+++ b/jekyll/_posts/2016-01-27-nim-in-action-now-available.md
@@ -3,6 +3,7 @@ title: "Nim in Action is now available!"
 excerpt: "We are proud to announce that Nim in Action, a book about
 the Nim programming language, is now available!"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 <div class="center">

--- a/jekyll/_posts/2016-06-04-meet-our-bountysource-sponsors.md
+++ b/jekyll/_posts/2016-06-04-meet-our-bountysource-sponsors.md
@@ -3,6 +3,7 @@ title: "Meet our BountySource sponsors"
 excerpt: "It has now been two months since we began our fundraiser. Time to meet
           our current sponsors."
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 <a href="{{site.baseurl}}/sponsors.html">

--- a/jekyll/_posts/2016-06-07-version-0140-released.md
+++ b/jekyll/_posts/2016-06-07-version-0140-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.14.0 released"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 It's been a while since the last release, but we've been very busy in the

--- a/jekyll/_posts/2016-06-09-version-0142-released.md
+++ b/jekyll/_posts/2016-06-09-version-0142-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.14.2 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 Version 0.14.2 is just a bugfix release that fixes the most pressing

--- a/jekyll/_posts/2016-06-23-community-survey-2016.md
+++ b/jekyll/_posts/2016-06-23-community-survey-2016.md
@@ -1,6 +1,7 @@
 ---
 title: "Launching the 2016 Nim Community Survey"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We are proud to announce the official

--- a/jekyll/_posts/2016-08-06-bountysource-update-the-road-to-v10.md
+++ b/jekyll/_posts/2016-08-06-bountysource-update-the-road-to-v10.md
@@ -1,6 +1,7 @@
 ---
 title: "BountySource Update: The Road to v1.0"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 *This was cross-posted from [update #4](https://salt.bountysource.com/teams/nim/updates/4-the-road-to-v1-0) on BountySource.*

--- a/jekyll/_posts/2016-09-03-community-survey-results-2016.md
+++ b/jekyll/_posts/2016-09-03-community-survey-results-2016.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim Community Survey Results"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We have recently closed the 2016 Nim Community Survey. I am happy to

--- a/jekyll/_posts/2016-09-30-version-0150-released.md
+++ b/jekyll/_posts/2016-09-30-version-0150-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.15.0 released"
 author: [Dominik Picheta, Andreas Rumpf]
+use_dark_highlighting: true
 ---
 
 We're happy to announce that the latest release of Nim, version 0.15.0, is now

--- a/jekyll/_posts/2016-10-23-version-0152-released.md
+++ b/jekyll/_posts/2016-10-23-version-0152-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.15.2 released"
 author: Andreas Rumpf
+use_dark_highlighting: true
 ---
 
 We're happy to announce that the latest release of Nim, version 0.15.2, is now

--- a/jekyll/_posts/2016-11-20-nim-in-action-in-production.md
+++ b/jekyll/_posts/2016-11-20-nim-in-action-in-production.md
@@ -5,6 +5,7 @@ on Nim in Action. The final manuscript has been submitted to Manning (the book's
 publisher), and the printed version is expected to start shipping in March
 2017 (give or take 1 month)."
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 <div class="center">

--- a/jekyll/_posts/2017-01-08-version-0160-released.md
+++ b/jekyll/_posts/2017-01-08-version-0160-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.16.0 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 We're happy to announce that the latest release of Nim, version 0.16.0, is now

--- a/jekyll/_posts/2017-05-17-version-0170-released.md
+++ b/jekyll/_posts/2017-05-17-version-0170-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.17.0 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2017-05-25-faster-command-line-tools-in-nim.md
+++ b/jekyll/_posts/2017-05-25-faster-command-line-tools-in-nim.md
@@ -1,6 +1,7 @@
 ---
 title: "Faster Command Line Tools in Nim"
 author: Euan Torano
+use_dark_highlighting: true
 ---
 
 *This is a guest post by Euan Torano cross-posted from [Faster Command Line Tools in Nim](https://www.euantorano.co.uk/posts/faster-command-line-tools-in-nim/). If you would like to publish articles as a guest author on nim-lang.org then get in touch with us via [Twitter](https://twitter.com/nim_lang) or [otherwise](https://github.com/nim-lang/website/issues).*

--- a/jekyll/_posts/2017-06-23-community-survey-2017.md
+++ b/jekyll/_posts/2017-06-23-community-survey-2017.md
@@ -1,6 +1,7 @@
 ---
 title: "Launching the 2017 Nim Community Survey"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We are proud to announce the launch of the official

--- a/jekyll/_posts/2017-09-07-version-0172-released.md
+++ b/jekyll/_posts/2017-09-07-version-0172-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.17.2 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2017-10-01-community-survey-results-2017.md
+++ b/jekyll/_posts/2017-10-01-community-survey-results-2017.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim Community Survey 2017 Results"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We have recently closed the 2017 Nim Community Survey. I am happy to

--- a/jekyll/_posts/2017-10-02-documenting-profiling-and-debugging-nim-code.adoc
+++ b/jekyll/_posts/2017-10-02-documenting-profiling-and-debugging-nim-code.adoc
@@ -1,6 +1,7 @@
 ---
 author: Dominik Picheta
 excerpt: This guide discusses some of the useful tools for documenting, profiling and debugging Nim code.
+use_dark_highlighting: true
 ---
 
 = A guide to documenting, profiling and debugging Nim code

--- a/jekyll/_posts/2017-12-28-nim-in-2017-a-short-recap.md
+++ b/jekyll/_posts/2017-12-28-nim-in-2017-a-short-recap.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim in 2017: A short recap"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 This year has been filled with some pretty major achievements for us, because

--- a/jekyll/_posts/2018-01-22-yes-command-in-nim.md
+++ b/jekyll/_posts/2018-01-22-yes-command-in-nim.md
@@ -2,6 +2,7 @@
 title: "yes command in Nim"
 author: Valts Liepiņš
 excerpt: "Recently I stumbled upon a post which takes a closer look at the `yes` command line tool. The main purpose of it is to write endless stream of a single letter `y` at a ridiculous speed."
+use_dark_highlighting: true
 ---
 
 <div class="sidebarblock">

--- a/jekyll/_posts/2018-01-28-nim-is-coming-to-fosdem.md
+++ b/jekyll/_posts/2018-01-28-nim-is-coming-to-fosdem.md
@@ -2,6 +2,7 @@
 title: "Nim is coming to FOSDEM"
 author: Dominik Picheta
 excerpt: "In just under a week, FOSDEM 2018 will be taking place in Brussels"
+use_dark_highlighting: true
 ---
 
 <div class="center">

--- a/jekyll/_posts/2018-03-01-version-0180-released.md
+++ b/jekyll/_posts/2018-03-01-version-0180-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.18.0 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2018-06-07-create-a-simple-macro.md
+++ b/jekyll/_posts/2018-06-07-create-a-simple-macro.md
@@ -6,6 +6,7 @@ metaprogramming using macros. Though a lot of Nim programmers are unaware of
 their merits due to lack of learning resources. The first part of
 this series will discuss the use of macros to simplify the creation of
 boilerplate code in Nim."
+use_dark_highlighting: true
 ---
 
 <div class="sidebarblock">

--- a/jekyll/_posts/2018-06-23-community-survey-2018.md
+++ b/jekyll/_posts/2018-06-23-community-survey-2018.md
@@ -1,6 +1,7 @@
 ---
 title: "Launching the 2018 Nim Community Survey"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We are proud to announce the launch of the official

--- a/jekyll/_posts/2018-08-07-nim-partners-with-status.md
+++ b/jekyll/_posts/2018-08-07-nim-partners-with-status.md
@@ -2,6 +2,7 @@
 title: "Nim partners with Status.im"
 author: Nim Team
 excerpt: "We're incredibly excited to announce the new partnership between Status and Nim."
+use_dark_highlighting: true
 ---
 
 <a href="{{ site.baseurl }}/assets/news/images/status/Status-Nim-partnership.png">

--- a/jekyll/_posts/2018-09-11-nim-is-hiring.md
+++ b/jekyll/_posts/2018-09-11-nim-is-hiring.md
@@ -3,6 +3,7 @@ title: "We're hiring!"
 author: Nim Team
 excerpt: "This is your chance to get to work with one of the leading experts in compiler
 development, meta programming and language design."
+use_dark_highlighting: true
 ---
 
 ## Become a Nim core developer

--- a/jekyll/_posts/2018-09-26-version-0190-released.md
+++ b/jekyll/_posts/2018-09-26-version-0190-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.19.0 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2018-10-01-hacktoberfest-with-nim.md
+++ b/jekyll/_posts/2018-10-01-hacktoberfest-with-nim.md
@@ -1,6 +1,7 @@
 ---
 title: Hacktoberfest with Nim
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 [Hacktoberfest](https://hacktoberfest.digitalocean.com/) is an annual event happening in October which celebrates open source software and encourages meaningful contributions to the open source ecosystem.

--- a/jekyll/_posts/2018-10-25-hired-krux02.md
+++ b/jekyll/_posts/2018-10-25-hired-krux02.md
@@ -2,6 +2,7 @@
 title: "Welcome our new team member, Arne Döring!"
 author: Nim Team
 excerpt: "We are glad that Arne Döring joined us as a fulltime core Nim developer."
+use_dark_highlighting: true
 ---
 
 Arne has been programming in Nim for quite some time now and has also contributed

--- a/jekyll/_posts/2018-10-27-community-survey-results-2018.md
+++ b/jekyll/_posts/2018-10-27-community-survey-results-2018.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim Community Survey 2018 Results"
 author: Dominik Picheta
+use_dark_highlighting: true
 ---
 
 We have recently closed the 2018 Nim Community Survey. I am happy to

--- a/jekyll/_posts/2018-11-26-advent-of-nim.md
+++ b/jekyll/_posts/2018-11-26-advent-of-nim.md
@@ -1,6 +1,7 @@
 ---
 title: Advent of Nim
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 Saturday December 1st at 5 a.m. UTC will mark the start of the fourth incarnation of [Advent of Code](https://adventofcode.com/), popular programming contest started back in 2015.

--- a/jekyll/_posts/2018-12-31-version-0192-released.md
+++ b/jekyll/_posts/2018-12-31-version-0192-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.19.2 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2019-01-08-nim-in-2018-a-short-recap.md
+++ b/jekyll/_posts/2019-01-08-nim-in-2018-a-short-recap.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim in 2018: A short recap"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 There were several big news in the Nim world in 2018 -- two new major releases, partnership with Status, and much more.

--- a/jekyll/_posts/2019-02-01-version-0194-released.md
+++ b/jekyll/_posts/2019-02-01-version-0194-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.19.4 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2019-05-13-version-0196-released.md
+++ b/jekyll/_posts/2019-05-13-version-0196-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.19.6 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce that the latest release of Nim,

--- a/jekyll/_posts/2019-06-06-version-0200-released.md
+++ b/jekyll/_posts/2019-06-06-version-0200-released.md
@@ -2,6 +2,7 @@
 title: "Version 0.20.0 released"
 author: The Nim Team
 excerpt: "We are very proud to announce Nim version 0.20. This is a massive release, both literally and figuratively. It contains more than 1,000 commits and it marks our release candidate for version 1.0!"
+use_dark_highlighting: true
 ---
 
 We are very proud to announce Nim version 0.20.

--- a/jekyll/_posts/2019-07-17-version-0202-released.md
+++ b/jekyll/_posts/2019-07-17-version-0202-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 0.20.2 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce version 0.20.2, which is our second

--- a/jekyll/_posts/2019-09-23-version-100-released.md
+++ b/jekyll/_posts/2019-09-23-version-100-released.md
@@ -2,6 +2,7 @@
 title: "Version 1.0 released"
 author: The Nim Team
 excerpt: "The Nim Team is very proud and happy to announce the much-anticipated version 1.0 of the language."
+use_dark_highlighting: true
 ---
 
 

--- a/jekyll/_posts/2019-10-23-version-102-released.md
+++ b/jekyll/_posts/2019-10-23-version-102-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 1.0.2 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce version 1.0.2, our first patch release following

--- a/jekyll/_posts/2019-11-26-version-104-released.md
+++ b/jekyll/_posts/2019-11-26-version-104-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 1.0.4 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce version 1.0.4, our second patch release following

--- a/jekyll/_posts/2019-12-20-community-survey-2019.md
+++ b/jekyll/_posts/2019-12-20-community-survey-2019.md
@@ -1,6 +1,7 @@
 ---
 title: "Launching the 2019 Nim Community Survey"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 We are proud to announce the launch of the official

--- a/jekyll/_posts/2020-01-24-version-106-released.md
+++ b/jekyll/_posts/2020-01-24-version-106-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 1.0.6 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce version 1.0.6, our third patch release following

--- a/jekyll/_posts/2020-02-18-community-survey-results-2019.md
+++ b/jekyll/_posts/2020-02-18-community-survey-results-2019.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim Community Survey 2019 Results"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 Nim community survey 2019 has been open for 50 days, and we have received 908 responses, which is our record-high number (771 in 2018, 603 in 2017).

--- a/jekyll/_posts/2020-04-03-version-120-released.md
+++ b/jekyll/_posts/2020-04-03-version-120-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 1.2.0 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 We are very proud to announce Nim version 1.2 after six months of continuous development!

--- a/jekyll/_posts/2020-05-14-nim-conference.md
+++ b/jekyll/_posts/2020-05-14-nim-conference.md
@@ -1,6 +1,7 @@
 ---
 title: "Nim Online Conference 2020"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 Mark the date: Saturday, June 20th 2020.

--- a/jekyll/_posts/2020-06-08-static-analysis.md
+++ b/jekyll/_posts/2020-06-08-static-analysis.md
@@ -2,6 +2,7 @@
 title: "Static Analysis"
 author: Moerm
 excerpt: "Nim is in an excellent position to “get married” with static analysis, and it doesn’t have to be based on some intermediate representation but can achieve a solution more similar to Spark."
+use_dark_highlighting: true
 ---
 
 <div class="sidebarblock">

--- a/jekyll/_posts/2020-06-17-version-122-released.md
+++ b/jekyll/_posts/2020-06-17-version-122-released.md
@@ -1,6 +1,7 @@
 ---
 title: "Version 1.2.2 released"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 The Nim team is happy to announce version 1.2.2, our first patch release for

--- a/jekyll/_posts/2020-06-19-NimConf.md
+++ b/jekyll/_posts/2020-06-19-NimConf.md
@@ -1,6 +1,7 @@
 ---
 title: "NimConf 2020"
 author: The Nim Team
+use_dark_highlighting: true
 ---
 
 NimConf is happening on Saturday June 20th 2020, don't miss it!

--- a/jekyll/assets/css/main.scss
+++ b/jekyll/assets/css/main.scss
@@ -62,6 +62,15 @@ a {
   }
 }
 
+div.highlight {
+  pre {
+    padding: 8px;
+    border-radius: 2px;
+  }
+  border-radius: 2px;
+  font-size: 0.875em;
+}
+
 figure.highlight {
   pre {
     padding: 8px;


### PR DESCRIPTION
Fixes #202

By the way, had to remove the `gemfile.lock` and the blog post with the `.adoc` extension to run it locally due to compilation errors.