### PR TITLE
Some changes to the FAQ

### DIFF
--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -84,7 +84,8 @@ whereas ``def`` stands for ``define``.
 ## Which option to use for the fastest executable?
 
 For the standard configuration file, ``-d:danger`` makes the fastest binary possible
-while disabling **all** runtime safety checks, so for most cases ``-d:release`` should
+while disabling **all** runtime safety checks including bound checks, overflow checks, 
+nil checks and more; for most cases ``-d:release`` should
 be enough. If supported by your compiler, you can also enable link-time optimization 
 for an even faster executable: ``--passc:-flto`` or ``-d:lto`` on Nim 1.4+
 

--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -61,6 +61,7 @@ glue code thanks to powerful metaprogramming capabilities of Nim.
 - Notepad++: [https://github.com/jangko/nppnim/releases](https://github.com/jangko/nppnim/releases)
 - Micro: Included
 - Atom: [https://atom.io/packages/nim](https://atom.io/packages/nim)
+- JetBrain IDEs: [https://plugins.jetbrains.com/plugin/15128-nim](https://plugins.jetbrains.com/plugin/15128-nim)
 
 ## What have been the major influences in the language's design?
 
@@ -80,15 +81,15 @@ whereas ``def`` stands for ``define``.
 
 ## Which option to use for the fastest executable?
 
-For the standard configuration file, ``-d:release`` does the trick.
+For the standard configuration file, ``-d:danger`` does the trick.
 If supported by your compiler, you can also enable link-time optimization
-for an even faster executable: ``--passc:-flto``
+for an even faster executable: ``-d:lto``
 
 ## Which option to use for the smallest executable?
 
-For the standard configuration file, ``-d:quick --opt:size`` does the trick.
+For the standard configuration file, ``-d:danger -d:strip --opt:size`` does the trick.
 If supported by your compiler, you can also enable link-time optimization
-for an even smaller executable: ``--passc:-flto``
+for an even smaller executable: ``-d:lto``
 
 ## How do I use a different C compiler than the default one?
 

--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -45,7 +45,6 @@ glue code thanks to powerful metaprogramming capabilities of Nim.
 
 ## What about editor support?
 
-- Aporia (native Nim editor): [https://github.com/nim-lang/Aporia](https://github.com/nim-lang/Aporia)
 - Visual Studio Code: [https://marketplace.visualstudio.com/items?itemName=kosz78.nim](https://marketplace.visualstudio.com/items?itemName=kosz78.nim)
 - Emacs: [https://github.com/nim-lang/nim-mode](https://github.com/nim-lang/nim-mode)
 - Vim: [https://github.com/zah/nimrod.vim/](https://github.com/zah/nimrod.vim)
@@ -63,6 +62,8 @@ glue code thanks to powerful metaprogramming capabilities of Nim.
 - Micro: Included
 - Atom: [https://atom.io/packages/nim](https://atom.io/packages/nim)
 - JetBrains IDEs: [https://plugins.jetbrains.com/plugin/15128-nim](https://plugins.jetbrains.com/plugin/15128-nim)
+- Kakoune: Included
+- For editors with LSP (Language Server Protocol) support (requires a separate syntax/indenting plugin): [https://github.com/PMunch/nimlsp](https://github.com/PMunch/nimlsp)
 
 ## What have been the major influences in the language's design?
 

--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -83,15 +83,16 @@ whereas ``def`` stands for ``define``.
 
 ## Which option to use for the fastest executable?
 
-For the standard configuration file, ``-d:danger`` does the trick.
-If supported by your compiler, you can also enable link-time optimization
-for an even faster executable: ``-d:lto``
+For the standard configuration file, ``-d:danger`` makes the fastest binary possible
+while disabling **all** runtime safety checks, so for most cases ``-d:release`` should
+be enough. If supported by your compiler, you can also enable link-time optimization 
+for an even faster executable: ``--passc:-flto`` or ``-d:lto`` on Nim 1.4+
 
 ## Which option to use for the smallest executable?
 
 For the standard configuration file, ``-d:danger -d:strip --opt:size`` does the trick.
 If supported by your compiler, you can also enable link-time optimization
-for an even smaller executable: ``-d:lto``
+the same way as described in the previous answer.
 
 ## How do I use a different C compiler than the default one?
 
@@ -100,16 +101,18 @@ Change the value of the ``cc`` variable to one of the following:
 
 | Abbreviation | C/C++ Compiler                          |
 | ---------------- | --------------------------------------------|
-|``vcc``           | Microsoft's Visual C++                      |
 |``gcc``           | GNU C compiler                              |
-|``llvm_gcc``      | LLVM-GCC compiler                           |
-|``icc``           | Intel C compiler                            |
 |``clang``         | Clang compiler                              |
-|``ucc``           | Generic UNIX C compiler                     |
+|``vcc``           | Microsoft's Visual C++                      |
+|``icc``           | Intel C compiler                            |
+|``llvm_gcc``      | LLVM-GCC compiler                           |
+|``tcc``           | Tiny C compiler                             |
+|``bcc``           | Borland C compiler                          |
+|``envcc``         | Your environment's default C compiler       |
 
 
 Other C compilers are not officially supported, but might work too.
 
 If your C compiler is not in the above list, try using the
-*generic UNIX C compiler* (``ucc``). If the C compiler needs
+*environment's default C compiler* (``envcc``). If the C compiler needs
 different command line arguments try the ``--passc`` and ``--passl`` switches.

--- a/jekyll/faq.md
+++ b/jekyll/faq.md
@@ -49,6 +49,7 @@ glue code thanks to powerful metaprogramming capabilities of Nim.
 - Visual Studio Code: [https://marketplace.visualstudio.com/items?itemName=kosz78.nim](https://marketplace.visualstudio.com/items?itemName=kosz78.nim)
 - Emacs: [https://github.com/nim-lang/nim-mode](https://github.com/nim-lang/nim-mode)
 - Vim: [https://github.com/zah/nimrod.vim/](https://github.com/zah/nimrod.vim)
+- NeoVim: [https://github.com/alaviss/nim.nvim](https://github.com/alaviss/nim.nvim)
 - QtCreator (4.1+): Included as experimental plugin.
 - Scite: Included
 - Gedit: The [Aporia .lang file](https://github.com/nim-lang/Aporia/blob/master/share/gtksourceview-2.0/language-specs/nim.lang).
@@ -61,7 +62,7 @@ glue code thanks to powerful metaprogramming capabilities of Nim.
 - Notepad++: [https://github.com/jangko/nppnim/releases](https://github.com/jangko/nppnim/releases)
 - Micro: Included
 - Atom: [https://atom.io/packages/nim](https://atom.io/packages/nim)
-- JetBrain IDEs: [https://plugins.jetbrains.com/plugin/15128-nim](https://plugins.jetbrains.com/plugin/15128-nim)
+- JetBrains IDEs: [https://plugins.jetbrains.com/plugin/15128-nim](https://plugins.jetbrains.com/plugin/15128-nim)
 
 ## What have been the major influences in the language's design?
 


### PR DESCRIPTION
I also wanted to add a warning for using -d:danger in that it disables all runtime checks, what would be the best wording (e.g. something "-d:danger provides the best executables, but for most cases -d:release is better since it provides good performance with safety checks enabled")

For -d:lto and -d:strip see https://github.com/nim-lang/Nim/commit/d27bc03b21ea066134a297e61d0d18c901300ccc. There's a problem though - that commit will only be included in 1.4, so maybe we should both tell the old and new ways for LTO? 

P.S.: Please add "hacktoberfest" tag to the repo since we're participating in it :)