### PR TITLE
code_carrousel: fix message in case statement

### DIFF
--- a/jekyll/code_carrousel.html
+++ b/jekyll/code_carrousel.html
@@ -112,7 +112,7 @@ of 'b', 'c':
 of 'd'..'h':
   echo "letter is between 'd' and 'h'"
 else:
-  echo "letter is between 'i' and 'z'"
+  echo "letter is another character"
 {% endhighlight %}
 </code>
 


### PR DESCRIPTION
A small suggestion for the nice new feature from https://github.com/nim-lang/website/pull/281. Pinging @juancarlospaco.

Otherwise, a new Nim user might think that a character can only be in `'a'..'z'`.

We could also consider renaming `letter` to `character`, or similar.

Bikeshedding: I guess it's deliberate that we use `var` rather than `let` or `const`. But we do use `let` in other examples. For a later PR, maybe we could use `let` everywhere, and add a tiny example with a `var` value that actually mutates? Dunno.