### PR TITLE
release article for nim 1.6.0

### DIFF
--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -391,7 +391,7 @@ Compatibility notes:
   active async event handles/file descriptors.
 - Added `getPort` to `std/asynchttpserver` to resolve OS-assigned `Port(0)`;
   this is usually recommended instead of hardcoding ports which can lead to "Address already in use" errors.
-- Fixed premature garbage collection in `std/asyncdispatch`, when a stack trace override is in place.
+- Fixed premature garbage collection in `std/asyncdispatch`, when a stacktrace override is in place.
 - Added `httpcore.is1xx` and missing HTTP codes.
 - Added `htmlgen.portal` for [making "SPA style" pages using HTML only](https://web.dev/hands-on-portals).
 
@@ -438,7 +438,7 @@ Compatibility notes:
 - environment variable APIs now work in multithreaded scenarios, by delegating to direct OS calls
   instead of trying to keep track of the environment.
 - `putEnv`, `delEnv` now work at CT.
-- `nodejs` backend now supports osenv: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
+- NodeJS backend now supports osenv: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
 
 Compatibility notes:
 - `std/os`: `putEnv` now raises if the 1st argument contains a `=`
@@ -459,10 +459,10 @@ Compatibility notes:
 
 
 ## `std/prelude`
-- `strformat` is now part of `include std/prelude`.
-- Added `sequtils` import to `prelude`.
-- `prelude` now works with the JS target.
-- `prelude` can now be used via `include std/prelude`, but `include prelude` still works.
+- `std/strformat` is now part of `include std/prelude`.
+- Added `std/sequtils` import to `std/prelude`.
+- `std/prelude` now works with the JS target.
+- `std/prelude` can now be used via `include std/prelude`, but `include prelude` still works.
 
 
 ## String manipulation: `std/strformat`, `std/strbasics`

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -11,25 +11,25 @@ Here are some stats:
 * 1667 PRs merged (1760 commits)
 * 893 issues closed
 * 15 new stdlib modules
-* new features in >40 stdlib modules, including major improvements to 10 commonly used modules.
+* new features in more than 40 stdlib modules, including major improvements to 10 commonly used modules.
 * documentation and minor improvements to 170 modules, including 312 new runnable examples
 * 280 new nimble packages
 
 Nim made its first entry in TIOBE index in 2017 at position 129,
-last year it entered the top-100, and in the last 2 months the top-50 (https://forum.nim-lang.org/t/8297).
+last year it entered the top-100, and in the last 2 months the top-50 ([https://forum.nim-lang.org/t/8297](https://forum.nim-lang.org/t/8297)).
 We hope this release will reinforce this trend, building on Nim's core strengths:
 a practical, compiled systems programming language; offering C-like performance and portability;
 Python-like syntax; LISP-like flexibility; strong C, C++, JS, Python interop;
 and best-in class metaprogramming.
 
 This release includes improvements in the following areas:
-* new language features (user defined literals, private imports, strict effects, `iterable[T]`, dot-like operators, block arguments with optional parameters)
+* new language features (user-defined literals, private imports, strict effects, `iterable[T]`, dot-like operators, block arguments with optional parameters)
 * new compiler features (`nim --eval:cmd`, custom nimscript extensions, customizable compiler messages)
 * major improvements to `--gc:arc` and `--gc:orc`
 * correctness and performance of integer and float parsing and rendering in all backends
 * significant improvements in error messages, showing useful context
-* doc generation logic and documentation, in particular `runnableExamples` now works in more contexts and replaces `code-block`.
-* made JS, VM and nimscript backend more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
+* documentation generation logic and documentation, in particular `runnableExamples` now works in more contexts
+* JS, VM and nimscript backend are more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
 * support for Apple silicon/M1, 32-bit RISC-V, CROSSOS, improved support for NodeJS backend
 * major improvements to the following modules: `system`, `math`, `random`, `json`, `jsonutils`, `os`, `typetraits`, `wrapnils`, `lists`, `hashes` including performance improvements
 * deprecated a number of error prone or redundant mis-features
@@ -120,7 +120,7 @@ template fn(a: iterable) # or template fn[T](a: iterable[T])
 # instead of:
 template fn(a: untyped)
 ```
-This solves a number of long standing issues related to iterators. In particular,
+This solves a number of long-standing issues related to iterators. In particular,
 iterable arguments can now be used with MCS, e.g. `iota(3).toSeq` now works.
 See PR [#17196](https://github.com/nim-lang/Nim/pull/17196) for additional details.
 
@@ -155,7 +155,7 @@ See PR [#17706](https://github.com/nim-lang/Nim/pull/17706) for additional detai
 
 
 ## `nim --eval:cmd`
-Added `nim --eval:cmd` to evaluate a command directly:, e.g.: `nim --eval:"echo 1"`.
+Added `nim --eval:cmd` to evaluate a command directly, e.g.: `nim --eval:"echo 1"`.
 It defaults to `e` (nimscript) but can also work with other commands, e.g.:
 ```bash
 find . | nim r --eval:'import strutils; for a in stdin.lines: echo a.toUpper'
@@ -224,7 +224,7 @@ assert readFile(path) == "foo"
 ```
 
 
-## User defined literals
+## User-defined literals
 Custom numeric literals (e.g. `-128'bignum`) are now supported.
 Additionally, the unary minus in `-1` is now part of the integer literal, i.e. it is now parsed as a single token.
 This implies that edge cases like `-128'i8` finally work correctly.
@@ -252,7 +252,7 @@ assert j.?a1.?a2.getInt == 10
 
 
 ## Block arguments now support optional parameters
-This solves a major pain point for routines accepting block parameters, see PR #18631 for details:
+This solves a major pain point for routines accepting block parameters, see PR [#18631](https://github.com/nim-lang/Nim/pull/18631) for details:
 ```nim
 template fn(a = 1, b = 2, body) = discard
 fn(1, 2): # already works
@@ -378,7 +378,7 @@ Compatibility notes:
   Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period. `toJson` now serializes `JsonNode`
   as is via reference (without a deep copy) instead of treating `JsonNode` as a regular ref object,
   this can be customized via `jsonNodeMode`.
-- `std/json` and `std/jsonutils` now serialize NaN, Inf, -Inf as strings, so that
+- `std/json` and `std/jsonutils` now serialize `NaN`, `Inf`, `-Inf` as strings, so that
   `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid JSON.
 - `std/json` can now handle integer literals and floating point literals of
   arbitrary length and precision.
@@ -459,7 +459,7 @@ Compatibility notes:
 
 
 ## Environment variable handling
-- empty environment variable values are now supported across OS's and backends
+- empty environment variable values are now supported across OS's and backends.
 - environment variable APIs now work in multithreaded scenarios, by delegating to direct OS calls
   instead of trying to keep track of the environment.
 - `putEnv`, `delEnv` now work at CT.
@@ -480,7 +480,7 @@ Compatibility notes:
   for previous behavior.
 - Added `posix_utils.osReleaseFile` to get system identification from `os-release` file on Linux and the BSDs.
   https://www.freedesktop.org/software/systemd/man/os-release.html
-- Remove undefined behavior for `posix.open`.
+- Removed undefined behavior for `posix.open`.
 
 
 ## `std/prelude`
@@ -492,8 +492,7 @@ Compatibility notes:
 
 ## String manipulation: `std/strformat`, `std/strbasics`
 - Added support for parenthesized expressions.
-- Added support for const string's instead of just string literals
-
+- Added support for const string's instead of just string literals.
 - Added `std/strbasics` for high performance string operations.
 - Added `strip`, `setSlice`, `add(a: var string, b: openArray[char])`.
 
@@ -510,7 +509,7 @@ Compatibility notes:
 
 
 ## Containers: `std/algorithm`, `std/lists`, `std/sequtils`, `std/options`, `std/packedsets`
-- Removed the optional `longestMatch` parameter of the `critbits._WithPrefix` iterators (it never worked reliably)
+- Removed the optional `longestMatch` parameter of the `critbits._WithPrefix` iterators (it never worked reliably).
 - Added `algorithm.merge`.
 - In `std/lists`: renamed `append` to `add` and retained `append` as an alias;
   added `prepend` and `prependMoved` analogously to `add` and `addMoved`;
@@ -520,8 +519,7 @@ Compatibility notes:
   shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
   its argument, `addMoved`, is also supplied. 
   See PR [#16362](https://github.com/nim-lang/Nim/pull/16362), [#16536](https://github.com/nim-lang/Nim/pull/16536).
-
-- New module: `std/packedsets`
+- New module: `std/packedsets`.
   Generalizes `std/intsets`, see PR [#15564](https://github.com/nim-lang/Nim/pull/15564).
 
 Compatibility notes:
@@ -542,19 +540,17 @@ Compatibility notes:
 - New module `std/genasts` containing `genAst` that avoids the problems inherent with `quote do` and can
   be used as a replacement.
   Use `-d:nimLegacyMacrosCollapseSymChoice` to get the previous behavior.
-
 - The required name of case statement macros for the experimental
   `caseStmtMacros` feature has changed from `match` to `` `case` ``.
 - Tuple expressions are now parsed consistently as
   `nnkTupleConstr` node. Will affect macros expecting nodes to be of `nnkPar`.
-- In `std/macros`, `treeRepr,lispRepr,astGenRepr` now represent SymChoice nodes in a collapsed way,
-
+- In `std/macros`, `treeRepr,lispRepr,astGenRepr` now represent SymChoice nodes in a collapsed way.
 - Make custom op in `macros.quote` work for all statements.
 
 
 ## `std/sugar`
 - Added `sugar.dumpToString` which improves on `sugar.dump`.
-- Added an overload for the `collect` macro that inferes the container type based
+- Added an overload for the `collect` macro that infers the container type based
   on the syntax of the last expression. Works with std seqs, tables and sets.
 
 Compatibility notes:
@@ -631,7 +627,6 @@ Compatibility notes:
 - The allocator for Nintendo Switch, which was nonfunctional because
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
 - Allow reading parameters when compiling for Nintendo Switch.
-
 - Cross compilation targeting Windows was improved
   This now works from macOS/Linux:
   `nim r -d:mingw main`
@@ -680,6 +675,7 @@ Compatibility notes:
   `.warning[AnyEnumConv]:on` or `--warning:AnyEnumConv:on`.
 
 - Reusing a type name in a different scope now works, refs [#17710](https://github.com/nim-lang/Nim/pull/17710).
+
 - Fixed implicit and explicit generics in procedures, refs [#18808](https://github.com/nim-lang/Nim/pull/18808).
 
 
@@ -748,7 +744,7 @@ Compatibility notes:
 ```
 
 - `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using Wine,
-  e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`
+  e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`.
 
 - `nim` can compile version 1.4.0 as follows: `nim c --lib:lib --stylecheck:off -d:nimVersion140 compiler/nim`.
   `-d:nimVersion140` is not needed for bootstrapping, only for building 1.4.0 from devel.
@@ -786,31 +782,25 @@ Compatibility notes:
 - docgen: RST files can now use single backticks instead of double backticks and correctly render
   in both `rst2html` (as before) as well as common tools rendering RST directly (e.g. GitHub). This is done by
   adding the `default-role:: code` directive inside the RST file (which is now handled by `rst2html`).
-
 - Source+Edit links now appear on top of every docgen'd page when
   `nim doc --git.url:url ...` is given.
-
 - Latex doc generation is revised: output `.tex` files should be compiled
   by `xelatex` (not by `pdflatex` as before). Now default Latex settings
   provide support for Unicode and do better job for avoiding margin overflows.
-
 - The RST parser now supports footnotes, citations, admonitions, short style references with symbols.
 - The RST parser now supports Markdown table syntax.
   Known limitations:
   - cell alignment is not supported, i.e. alignment annotations in a delimiter
     row (`:---`, `:--:`, `---:`) are ignored,
   - every table row must start with `|`, e.g. `| cell 1 | cell 2 |`.
-
 - Implemented `doc2tex` compiler command which converts documentation in
   `.nim` files to Latex.
-
 - docgen now supports syntax highlighting for inline code.
 - docgen now supports same line doc comments:
 ```nim
 func fn*(a: int): int = 42  ## Doc comment
 ```
 - docgen now renders deprecated and other pragmas.
-
 - `runnableExamples` now works with templates and nested templates.
 - `runnableExamples: "-r:off"` now works for examples that should compile but not run. 
 - `runnableExamples` now renders code verbatim, and produces correct code in all cases.
@@ -830,7 +820,6 @@ func fn*(a: int): int = 42  ## Doc comment
 ](https://github.com/nim-lang/Nim/pull/15612).
 - `fusion` is now un-bundled from Nim, `./koch fusion` will
   install it via Nimble at a fixed hash.
-
 - `testament`: added `nimoutFull: bool` spec to compare full output of compiler
   instead of a subset; many bugfixes to testament.
 
@@ -838,6 +827,6 @@ func fn*(a: int): int = 42  ## Doc comment
 ## Misc/cleanups
 - Deprecated `TaintedString` and `--taintmode`.
 - Deprecated `--nilseqs` which is now a noop.
-- Added `-d:nimStrictMode` in CI in several places to ensure code doesn't have certain hints/warnings
+- Added `-d:nimStrictMode` in CI in several places to ensure code doesn't have certain hints/warnings.
 - Removed `.travis.yml`, `appveyor.yml.disabled`, `.github/workflows/ci.yml.disabled`.
-- `[skip ci]` now works in azure and CI pipelines, see detail in PR [#17561](https://github.com/nim-lang/Nim/pull/17561)
+- `[skip ci]` now works in azure and CI pipelines, see detail in PR [#17561](https://github.com/nim-lang/Nim/pull/17561).

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -123,16 +123,31 @@ See PR [#17196](https://github.com/nim-lang/Nim/pull/17196) for additional detai
 
 
 ## Private imports and private field access
-- A new import syntax `import foo {.all.}` now allows to import all symbols (public or private)
-  from `foo`. This can be useful for testing purposes or for more flexibility in project organization.
-- Added a new module `std/importutils`, and an API `privateAccess`, which allows access to private fields
-  for an object type in the current scope.
+A new import syntax `import foo {.all.}` now allows to import all symbols (public or private) from `foo`.
+This can be useful for testing purposes or for more flexibility in project organization.
+
 Example:
 ```nim
-from system as system2 {.all.} import ThisIsSystem
-import os {.all.}
-assert weirdTarget
+from system {.all.} as system2 import nil
+echo system2.ThisIsSystem # ThisIsSystem is private in `system`
+import os {.all.} # weirdTarget is private in `os`
+echo weirdTarget # or `os.weirdTarget`
 ```
+
+Added a new module `std/importutils`, and an API `privateAccess`, which allows access
+to private fields for an object type in the current scope.
+
+Example:
+```nim
+import times
+from std/importutils import privateAccess
+block:
+  let t = now()
+  # echo t.monthdayZero # Error: undeclared field: 'monthdayZero' for type times.DateTime
+  privateAccess(typeof(t)) # enables private access in this scope
+  echo t.monthdayZero # ok
+```
+
 
 ## `nim --eval:cmd`
 Added `nim --eval:cmd` to evaluate a command directly:, e.g.: `nim --eval:"echo 1"`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -579,42 +579,42 @@ Compatibility notes:
 
 
 ## JS stdlib changes
-- Added `std/jsbigints` module, arbitrary precision integers for JS target.
-- Added `setCurrentException` for JS backend.
-- `writeStackTrace` is available in JS backend now.
+- Added `std/jsbigints` module, arbitrary precision integers for the JS target.
+- Added `setCurrentException` for the JS backend.
+- `writeStackTrace` is available in the JS backend now.
 - Added `then`, `catch` to `std/asyncjs` for promise pipelining, for now hidden behind `-d:nimExperimentalAsyncjsThen`.
-- Added `std/jsfetch` module [Fetch](https://developer.mozilla.org/docs/Web/API/Fetch_API) wrapper for JS target.
-- Added `std/jsheaders` module [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) wrapper for JS target.
-- Added `std/jsformdata` module [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) wrapper for JS target.
-- Added `jscore.debugger` to [call any available debugging functionality, such as breakpoints.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger).
+- Added `std/jsfetch` module [Fetch](https://developer.mozilla.org/docs/Web/API/Fetch_API) wrapper for the JS target.
+- Added `std/jsheaders` module [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) wrapper for the JS target.
+- Added `std/jsformdata` module [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) wrapper for the JS target.
+- Added `jscore.debugger` to [call any available debugging functionality, such as breakpoints](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger).
 - Added `jsconsole.dir`, `jsconsole.dirxml`, `jsconsole.timeStamp`.
 - Added dollar `$` and `len` for `jsre.RegExp`.
-- Added `jsconsole.jsAssert` for JS target.
+- Added `jsconsole.jsAssert` for the JS target.
 - Added `**` to `std/jsffi`.
 - Added `copyWithin` [for `seq` and `array` for JS targets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin).
 - In `std/dom`, `Interval` is now a `ref object`, same as `Timeout`. Definitions of `setTimeout`,
   `clearTimeout`, `setInterval`, `clearInterval` were updated.
-- Added `dom.scrollIntoView` proc with options
+- Added `dom.scrollIntoView` proc with options.
 - Added `dom.setInterval`, `dom.clearInterval` overloads.
-- Merged `std/dom_extensions` module into `std/dom` module,
+- Merged `std/dom_extensions` into the `std/dom` module,
   it was a module with a single line, see RFC [#413](https://github.com/nim-lang/RFCs/issues/413).
-- `$` now gives more correct results on JS backend.
+- `$` now gives more correct results on the JS backend.
 
 
 ## JS compiler changes
-- The `cstring` doesn't support `[]=` operator in JS backend.
-- Now array literals(JS backend) uses JS typed arrays when the corresponding JS typed array exists,
+- `cstring` doesn't support the `[]=` operator anymore in the JS backend.
+- Array literals now use JS typed arrays when the corresponding JS typed array exists,
   for example `[byte(1), 2, 3]` generates `new Uint8Array([1, 2, 3])`.
 
 
 ## VM and nimscript backend
-- VM now supports `addr(mystring[ind])` (index + index assignment)
+- VM now supports `addr(mystring[ind])` (index + index assignment).
 - `nimscript` now handles `except Exception as e`.
-- nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
+- `nil` dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
 - `static[T]` now works better, refs [#17590](https://github.com/nim-lang/Nim/pull/17590), [#15853](https://github.com/nim-lang/Nim/pull/15853).
-- `distinct T` conversions now works in VM.
-- `items(cstring)` now works in VM
-- fix `addr`, `len`, `high` in VM ([#16002](https://github.com/nim-lang/Nim/pull/16002), [#16610](https://github.com/nim-lang/Nim/pull/16610)).
+- `distinct T` conversions now work in VM.
+- `items(cstring)` now works in VM.
+- Fix `addr`, `len`, `high` in VM ([#16002](https://github.com/nim-lang/Nim/pull/16002), [#16610](https://github.com/nim-lang/Nim/pull/16610)).
 - `std/cstrutils` now works in VM.
 
 
@@ -627,20 +627,20 @@ Compatibility notes:
 - Allow reading parameters when compiling for Nintendo Switch.
 
 - Cross compilation targeting Windows was improved
-  This now works from OSX/Linux:
+  This now works from macOS/Linux:
   `nim r -d:mingw main`
   `--nimcache` now correctly works in a cross-compilation setting.
 
 
 ## Performance / memory optimizations
 - The comment field in PNode AST was moved to a side channel, reducing overall memory usage during compilation by a factor 1.25x
-- `std/jsonutils` deserialization is now up to 20x faster
-- `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`;
-  use `-d:nimLegacyCopyFile` for OSX < 10.5.
-- float to string is now 10x faster thanks to Dragonbox algorithm, with `-d:nimPreviewFloatRoundtrip`.
-- `newSeqWith` is 3x faster
+- `std/jsonutils` deserialization is now up to 20x faster.
+- `os.copyFile` is now 2.5x faster on macOS, by using `copyfile` from `copyfile.h`;
+  use `-d:nimLegacyCopyFile` for macOS < 10.5.
+- Float to string conversion is now 10x faster thanks to the Dragonbox algorithm, with `-d:nimPreviewFloatRoundtrip`.
+- `newSeqWith` is 3x faster.
 - CI now supports batching (making Windows CI 2.3X faster).
-- sets now uses optimized `countSetBits`, see PR [#17334](https://github.com/nim-lang/Nim/pull/17334).
+- Sets now uses the optimized `countSetBits` proc, see PR [#17334](https://github.com/nim-lang/Nim/pull/17334).
 
 ## Debugging
 - You can now enable/disable VM tracing in user code via `vmutils.vmTrace`.
@@ -695,7 +695,7 @@ See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
   pragma `{.experimental: "unicodeOperators".}` reliably, you need to enable
   it via the command line or in a configuration file.
 
-- `var a{.foo.} = expr` now works inside templates (except when `foo` is overloaded).
+- `var a {.foo.} = expr` now works inside templates (except when `foo` is overloaded).
 
 
 ## Compiler messages, error messages, hints, warnings
@@ -721,10 +721,10 @@ See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
 - `typedesc[Foo]` now renders as such instead of `type Foo` in compiler messages.
 - `runnableExamples` now show originating location in stacktraces on failure.
 - `SuccessX` message now shows more useful information.
-- new `DuplicateModuleImport` warning, and improved `UnusedImport` and `XDeclaredButNotUsed` accuracy.
+- New `DuplicateModuleImport` warning, improved `UnusedImport` and `XDeclaredButNotUsed` accuracy.
 
 Compatibility notes:
-- `--hint:CC` now goes to stderr (like all other hints) instead of stdout.
+- `--hint:CC` now prints to stderr (like all other hints) instead of stdout.
 
 
 ## Building and running Nim programs, configuration system
@@ -755,7 +755,7 @@ Compatibility notes:
 
 
 ## Multithreading
-- TLS: OSX now uses native TLS (`--tlsEmulation:off`), TLS now works with importcpp non-POD types,
+- TLS: macOS now uses native TLS (`--tlsEmulation:off`), TLS now works with `importcpp` non-POD types,
   such types must use `.cppNonPod` and `--tlsEmulation:off`should be used.
 - Added `unsafeIsolate` and `extract` to `std/isolation`.
 - Added `std/tasks`, a new module containing primitives for creating parallel programs.
@@ -778,8 +778,8 @@ Compatibility notes:
 
 ## Docgen
 - docgen: RST files can now use single backticks instead of double backticks and correctly render
-  in both `rst2html` (as before) as well as common tools rendering RST directly (e.g. GitHub), by
-  adding: `default-role:: code` directive inside the RST file, which is now handled by `rst2html`.
+  in both `rst2html` (as before) as well as common tools rendering RST directly (e.g. GitHub). This is done by
+  adding the `default-role:: code` directive inside the RST file (which is now handled by `rst2html`).
 
 - Source+Edit links now appear on top of every docgen'd page when
   `nim doc --git.url:url ...` is given.
@@ -820,7 +820,7 @@ func fn*(a: int): int = 42  ## Doc comment
   for more details.
 
 ## Tools
-- major improvements to `nimgrep`, see PR [#15612
+- Major improvements to `nimgrep`, see PR [#15612
 ](https://github.com/nim-lang/Nim/pull/15612).
 - `fusion` is now un-bundled from Nim, `./koch fusion` will
   install it via Nimble at a fixed hash.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -281,8 +281,8 @@ The following modules were added (they are discussed in the rest of the text):
 - Added `genEnumCaseStmt` macro that generates
   case statement to parse string to enum.
 - Added `items` for enums with holes.
-- Added `symbolName` to return the enum symbol name ignoring the human readable name.
-- Added `symbolRank` to return the index in which an enum member is listed in an enum.
+- Added `symbolName` to return the `enum` symbol name ignoring the human readable name.
+- Added `symbolRank` to return the index in which an `enum` member is listed in an enum.
 
 
 ## `system`
@@ -386,7 +386,7 @@ Compatibility notes:
 - Exported `sslHandle` from `std/net` and `std/asyncnet`.
 - Added `hasDataBuffered` to `std/asyncnet`.
 - various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover `request` function's
-  `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` enum type; see #15919.
+  `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` `enum` type; see #15919.
 - Added `asyncdispatch.activeDescriptors` that returns the number of currently
   active async event handles/file descriptors.
 - Added `getPort` to `std/asynchttpserver` to resolve OS-assigned `Port(0)`;
@@ -632,12 +632,12 @@ Compatibility notes:
 
 ## Type system
 - `typeof(voidStmt)` now works and returns `void`.
-- Enum values can now be overloaded. This needs to be enabled
+- `enum` values can now be overloaded. This needs to be enabled
   via `{.experimental: "overloadableEnums".}`. We hope that this feature allows for the
   development of more fluent (less ugly) APIs. See https://github.com/nim-lang/RFCs/issues/373
   for more details.
 
-- A type conversion from one enum type to another now produces an `[EnumConv]` warning.
+- A type conversion from one `enum` type to another now produces an `[EnumConv]` warning.
   You should use `ord` (or `cast`, but the compiler won't help, if you misuse it) instead.
   ```
   type A = enum a1, a2
@@ -650,7 +650,7 @@ Compatibility notes:
   This warning will become an error in future versions! Use an explicit conversion
   like `cstring(x)` in order to silence the warning.
 
-- There is a new warning for *any* type conversion to enum that can be enabled via
+- There is a new warning for *any* type conversion to `enum` that can be enabled via
   `.warning[AnyEnumConv]:on` or `--warning:AnyEnumConv:on`.
 
 - Reusing a type name in a different scope now works, refs #17710.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -17,12 +17,12 @@ Nim made its first entry in TIOBE index in 2017 at position 129, last year it en
 This release includes improvements in the following areas:
 * new language features (user defined literals, private imports, strict effects, `iterable[T]`, new style concepts, dot-like operators, block arguments with optional params)
 * new compiler features (`nim --eval:cmd`, custom nimscript extensions, customizable compiler messages)
-* major improvements to gc:arc, gc:orc
+* major improvements to `--gc:arc`, `--gc:orc`
 * correctness and performance of integer and float parsing and rendering in all backends
 * significant improvements in error messages, showing useful context
 * doc generation logic and documentation, in particular `runnableExamples` now works in more contexts and replaces `code-block`.
 * made JS, VM and nimscript backend more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
-* support for apple silicon/M1 macs, 32-bit RISC-V, improved support for nodejs backend
+* support for Apple silicon/M1, 32-bit RISC-V, improved support for NodeJS backend
 * major improvements to the following modules: `system, math, random, json, jsonutils, os, typetraits, wrapnils, lists, hashes` including performance improvements
 * deprecated a number of error prone or redundant mis-features
 
@@ -95,10 +95,9 @@ else:
   {.pragma: effectsOf.}
 
 proc mysort(s: seq; cmp: proc(a, b: T): int) {.effectsOf: cmp.}
-
 ```
 
-To enable the new effect system, use --experimental:strictEffects. See #18777 and RFC #408.
+To enable the new effect system, use --experimental:strictEffects. See [#18777](https://github.com/nim-lang/Nim/pull/18777) and RFC [#408](https://github.com/nim-lang/RFCs/issues/408).
 
 
 ## `iterable[T]`
@@ -110,7 +109,7 @@ template fn(a: untyped)
 ```
 This solves a number of long standing issues related to iterators. In particular,
 iterable arguments can now be used with MCS, e.g. `iota(3).toSeq` now works.
-See PR #17196 for additional details.
+See PR [#17196](https://github.com/nim-lang/Nim/pull/17196) for additional details.
 
 
 ## Private imports and private field access
@@ -136,7 +135,7 @@ You can also use it to explore a module's APIs, including private symbols:
 ```bash
 nim --eval:'import os {.all.}; echo weirdTarget'
 ```
-See PR #15687 for more details.
+See PR [#15687](https://github.com/nim-lang/Nim/pull/15687) for more details.
 
 
 ## Round-trip float to string
@@ -161,7 +160,7 @@ assert big"2" ** big"64" == big"18446744073709551616"
 ```
 
 ## New `std/sysrand` module
-Cryptographically secure pseudorandom number generator, see PR #16459.
+Cryptographically secure pseudorandom number generator, see PR [#16459](https://github.com/nim-lang/Nim/pull/16459).
 Example:
 ```nim
 import std/sysrand
@@ -206,7 +205,7 @@ type
   Comparable = concept # no T, an atom
     proc cmp(a, b: Self): int
 ```
-See PR #15251 for details.
+See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
 
 
 ## Dot-like operators
@@ -287,7 +286,7 @@ The following modules were added (they are discussed in the rest of the text):
 
 ## `system`
 - Added `system.prepareStrMutation` for better support of low
-  level `moveMem`, `copyMem` operations for Orc's copy-on-write string
+  level `moveMem`, `copyMem` operations for `gc:orc`'s copy-on-write string
   implementation.
 - `system.addEscapedChar` now renders `\r` as `\r` instead of `\c`, to be compatible
   with most other languages.
@@ -308,9 +307,9 @@ Compatibility notes:
 - `cuchar` is now deprecated as it aliased `char` where arguably it should have aliased `uint8`.
   Please use `char` or `uint8` instead.
 - `repr` now doesn't insert trailing newline; previous behavior was very inconsistent,
-  see #16034. Use `-d:nimLegacyReprWithNewline` for previous behavior. `repr` now also
+  see [#16034](https://github.com/nim-lang/Nim/pull/16034). Use `-d:nimLegacyReprWithNewline` for previous behavior. `repr` now also
   renders ASTs correctly for user defined literals, setters, `do`, etc.
-- Deprecated `any`. See https://github.com/nim-lang/RFCs/issues/281
+- Deprecated `any`. See RFC [#281](https://github.com/nim-lang/RFCs/issues/281).
 - The unary slice `..b` was deprecated, use `0..b` instead.
 
 
@@ -326,7 +325,7 @@ Compatibility notes:
 
 Compatibility notes:
 - `math.round` now is rounded "away from zero" in JS backend which is consistent
-  with other backends. See #9125. Use `-d:nimLegacyJsRound` for previous behavior.
+  with other backends. See [#9125](https://github.com/nim-lang/Nim/pull/9125). Use `-d:nimLegacyJsRound` for previous behavior.
 
 
 ## Random number generators: `std/random`, `std/sysrand`, `std/oids`
@@ -336,14 +335,14 @@ Compatibility notes:
 - `initRand(seed)` now allows `seed == 0`.
 - Added `std/sysrand` module to get random numbers from a secure source
 - Fixed overflow bugs.
-- Fix initrand to avoid random number sequences overlapping, refs #18744.
+- Fix `initRand` to avoid random number sequences overlapping, refs [#18744](https://github.com/nim-lang/Nim/pull/18744).
 - `std/oids` now uses `std/random`.
 
 Compatibility notes:
 - Deprecated `std/mersenne`.
 - `random.initRand(seed)` now produces non-skewed values for the 1st call to `rand()` after
   initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
-  previous behavior for a transition time, see PR #17467.
+  previous behavior for a transition time, see PR [#17467](https://github.com/nim-lang/Nim/pull/17467).
   provided by the operating system.
 
 
@@ -353,7 +352,7 @@ Compatibility notes:
   as is via reference (without a deep copy) instead of treating `JsonNode` as a regular ref object,
   this can be customized via `jsonNodeMode`.
 - `std/json` and `std/jsonutils` now serialize NaN, Inf, -Inf as strings, so that
-  `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid json.
+  `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid JSON.
 - `std/json` can now handle integer literals and floating point literals of
   arbitrary length and precision.
   Numbers that do not fit the underlying `BiggestInt` or `BiggestFloat` fields are
@@ -415,7 +414,7 @@ Compatibility notes:
 - `os.FileInfo` (returned by `getFileInfo`) now contains `blockSize`,
   determining preferred I/O block size for this file object.
 - Added `os.getCacheDir()` to return platform specific cache directory.
-- Improved `os.getTempDir()`, see PR #16914.
+- Improved `os.getTempDir()`, see PR [#16914](https://github.com/nim-lang/Nim/pull/16914).
 - Added `os.isAdmin` to tell whether the caller's process is a member of the
   Administrators local group (on Windows) or a root (on POSIX).
 - Added optional `options` argument to `copyFile`, `copyFileToDir`, and
@@ -475,7 +474,7 @@ Compatibility notes:
 
 ## `std/wrapnils`
 - `std/wrapnils` doesn't use `experimental:dotOperators` anymore, avoiding
-  issues like bug #13063 (which affected error messages)
+  issues like bug [#13063](https://github.com/nim-lang/Nim/issues/13063) (which affected error messages)
   for modules importing `std/wrapnils`.
   Added `??.` macro which returns an `Option`.
   `std/wrapnils` can now be used to protect against `FieldDefect` errors in
@@ -494,7 +493,7 @@ Compatibility notes:
   and `lists.toDoublyLinkedList` convert from `openArray`s; `lists.copy` implements
   shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
   its argument, `addMoved`, is also supplied. 
-  See PR #16362, #16536.
+  See PR [#16362](https://github.com/nim-lang/Nim/pull/16362), [#16536](https://github.com/nim-lang/Nim/pull/16536).
 
 - new module: `std/packedsets`
   Generalizes `std/intsets`, see PR #15564.
@@ -543,12 +542,12 @@ Compatibility notes:
   returning a tuple which can be unpacked for easier usage of `scanf`.
 - Added `decodeQuery` to `std/uri`.
 - `parseopt.initOptParser` has been made available and `parseopt` has been
-  added back to `prelude` for all backends. Previously `initOptParser` was
-  unavailable if the `os` module did not have `paramCount` or `paramStr`,
+  added back to `std/prelude` for all backends. Previously `initOptParser` was
+  unavailable if the `std/os` module did not have `paramCount` or `paramStr`,
   but the use of these in `initOptParser` were conditionally to the runtime
   arguments passed to it, so `initOptParser` has been changed to raise
   `ValueError` when the real command line is not available. `parseopt` was
-  previously excluded from `prelude` for JS, as it could not be imported.
+  previously excluded from `std/prelude` for JS, as it could not be imported.
 
 Compatibility notes:
 - Changed the behavior of `uri.decodeQuery` when there are unencoded `=`
@@ -561,9 +560,9 @@ Compatibility notes:
 
 ## JS stdlib changes
 - Added `std/jsbigints` module, arbitrary precision integers for JS target.
-- Added setCurrentException for JS backend.
+- Added `setCurrentException` for JS backend.
 - `writeStackTrace` is available in JS backend now.
-- Added `then`, `catch` to `asyncjs` for promise pipelining, for now hidden behind `-d:nimExperimentalAsyncjsThen`.
+- Added `then`, `catch` to `std/asyncjs` for promise pipelining, for now hidden behind `-d:nimExperimentalAsyncjsThen`.
 - Added `std/jsfetch` module [Fetch](https://developer.mozilla.org/docs/Web/API/Fetch_API) wrapper for JS target.
 - Added `std/jsheaders` module [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) wrapper for JS target.
 - Added `std/jsformdata` module [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) wrapper for JS target.
@@ -578,7 +577,7 @@ Compatibility notes:
 - Added `dom.scrollIntoView` proc with options
 - Added `dom.setInterval`, `dom.clearInterval` overloads.
 - Merged `std/dom_extensions` module into `std/dom` module,
-  it was a module with a single line, see https://github.com/nim-lang/RFCs/issues/413
+  it was a module with a single line, see RFC [#413](https://github.com/nim-lang/RFCs/issues/413).
 - `$` now gives more correct results on JS backend.
 
 
@@ -592,40 +591,40 @@ Compatibility notes:
 - VM now supports `addr(mystring[ind])` (index + index assignment)
 - `nimscript` now handles `except Exception as e`.
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
-- `static[T]` now works better, refs #17590, #15853.
+- `static[T]` now works better, refs [#17590](https://github.com/nim-lang/Nim/pull/17590), [#15853](https://github.com/nim-lang/Nim/pull/15853).
 - `distinct T` conversions now works in VM.
 - `items(cstring)` now works in VM
-- fix `addr`, `len`, `high` in VM (#16002, #16610).
+- fix `addr`, `len`, `high` in VM ([#16002](https://github.com/nim-lang/Nim/pull/16002), [#16610](https://github.com/nim-lang/Nim/pull/16610)).
 - `std/cstrutils` now works in VM.
 
 
 ## OS-specific notes
-- Support for apple silicon/M1 macs.
-- Support for 32-bit RISC-V, refs #16231.
+- Support for Apple silicon/M1.
+- Support for 32-bit RISC-V, refs [#16231](https://github.com/nim-lang/Nim/pull/16231).
 - The allocator for Nintendo Switch, which was nonfunctional because
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
 - Allow reading parameters when compiling for Nintendo Switch.
 
-- Cross compilation targetting windows was improved
-  This now works from osx/linux:
+- Cross compilation targeting Windows was improved
+  This now works from OSX/Linux:
   `nim r -d:mingw main`
   `--nimcache` now correctly works in a cross-compilation setting.
 
 
 ## Performance / memory optimizations
 - The comment field in PNode AST was moved to a side channel, reducing overall memory usage during compilation by a factor 1.25x
-- jsonutils deserialization is now up to 20x faster
+- `std/jsonutils` deserialization is now up to 20x faster
 - `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`;
   use `-d:nimLegacyCopyFile` for OSX < 10.5.
-- float to string is now 10x faster thanks to dragonbox algorithm, with `-d:nimPreviewFloatRoundtrip`.
+- float to string is now 10x faster thanks to Dragonbox algorithm, with `-d:nimPreviewFloatRoundtrip`.
 - `newSeqWith` is 3x faster
-- CI now supports batching (making windows CI 2.3X faster).
-- sets now uses optimized `countSetBits`, see PR #17334.
+- CI now supports batching (making Windows CI 2.3X faster).
+- sets now uses optimized `countSetBits`, see PR [#17334](https://github.com/nim-lang/Nim/pull/17334).
 
 ## Debugging
 - You can now enable/disable VM tracing in user code via `vmutils.vmTrace`.
-- `koch tools` now builds `bin/nim_dbg` which allows easy access to a debug version of nim without recompiling.
-- Added new module `compiler/debugutils` to help with debugging nim compiler.
+- `koch tools` now builds `bin/nim_dbg` which allows easy access to a debug version of Nim without recompiling.
+- Added new module `compiler/debugutils` to help with debugging Nim compiler.
 - Renamed `-d:nimCompilerStackraceHints` to `-d:nimCompilerStacktraceHints` and used it in more contexts;
   this flag which works in tandem with `--stackTraceMsgs` to show user code context in compiler stacktraces.
 
@@ -634,7 +633,7 @@ Compatibility notes:
 - `typeof(voidStmt)` now works and returns `void`.
 - `enum` values can now be overloaded. This needs to be enabled
   via `{.experimental: "overloadableEnums".}`. We hope that this feature allows for the
-  development of more fluent (less ugly) APIs. See https://github.com/nim-lang/RFCs/issues/373
+  development of more fluent (less ugly) APIs. See RFC [#373](https://github.com/nim-lang/RFCs/issues/373).
   for more details.
 
 - A type conversion from one `enum` type to another now produces an `[EnumConv]` warning.
@@ -653,8 +652,8 @@ Compatibility notes:
 - There is a new warning for *any* type conversion to `enum` that can be enabled via
   `.warning[AnyEnumConv]:on` or `--warning:AnyEnumConv:on`.
 
-- Reusing a type name in a different scope now works, refs #17710.
-- Fixed implicit and explicit generics in procedures, refs #18808.
+- Reusing a type name in a different scope now works, refs [#17710](https://github.com/nim-lang/Nim/pull/17710).
+- Fixed implicit and explicit generics in procedures, refs [#18808](https://github.com/nim-lang/Nim/pull/18808).
 
 
 ## Lexical / syntactic
@@ -669,7 +668,7 @@ Compatibility notes:
 
 
 ## Compiler messages, error messages, hints, warnings
-- Significant improvement to error messages involving effect mismatches, see PRs #18384, #18418.
+- Significant improvement to error messages involving effect mismatches, see PRs [#18384](https://github.com/nim-lang/Nim/pull/18384), [#18418](https://github.com/nim-lang/Nim/pull/18418).
 - Added `--declaredLocs` to show symbol declaration location in error messages.
 - Added `--spellSuggest` to show spelling suggestions on typos.
 - Added `--processing:dots|filenames|off` which customizes `hintProcessing`;
@@ -678,7 +677,7 @@ Compatibility notes:
 - Added `--hintAsError` with similar semantics as `--warningAsError`.
 - Added `--unitsep:on|off` to control whether to add ASCII unit separator `\31` before a newline
  for every generated message (potentially multiline), so tooling can tell when messages start and end.
-- Added `--filenames:abs|canonical|legacyRelProj` which replaces --listFullPaths:on|off
+- Added `--filenames:abs|canonical|legacyRelProj` which replaces `--listFullPaths:on|off`
 - `--hint:all:on|off` is now supported to select or deselect all hints; it
   differs from `--hints:on|off` which acts as a (reversible) gate.
   Likewise with `--warning:all:on|off`.
@@ -698,20 +697,20 @@ Compatibility notes:
 
 
 ## Building and running Nim programs, configuration system
-- json build instructions are now generated in `$nimcache/outFileBasename.json`
+- JSON build instructions are now generated in `$nimcache/outFileBasename.json`
   instead of `$nimcache/projectName.json`. This allows avoiding recompiling a given project
   compiled with different options if the output file differs.
 
 - `--usenimcache` (implied by `nim r main`) now generates an output file that includes a hash of
   some of the compilation options, which allows caching generated binaries:
-  ```bash
+```bash
   nim r main # recompiles
   nim r -d:foo main # recompiles
   nim r main # uses cached binary
   nim r main arg1 arg2 # ditto (runtime arguments are irrelevant)
 ```
 
-- `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using wine,
+- `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using Wine,
   e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`
 
 - `nim` can compile version 1.4.0 as follows: `nim c --lib:lib --stylecheck:off -d:nimVersion140 compiler/nim`.
@@ -732,11 +731,11 @@ Compatibility notes:
 
 
 ## Memory management
-- `--gc:arc` now bootstraps (#PR 17342).
-- Lots of improvements to gc:arc, gc:orc, refs PR #15697, #16849, #17993.
+- `--gc:arc` now bootstraps (PR [#17342](https://github.com/nim-lang/Nim/pull/17342)).
+- Lots of improvements to `gc:arc`, `gc:orc`, refs PR [#15697](https://github.com/nim-lang/Nim/pull/15697), [#16849](https://github.com/nim-lang/Nim/pull/16849), [#17993](https://github.com/nim-lang/Nim/pull/17993).
 - `--gc:orc` is now 10% faster than previously for common workloads. If
   you have trouble with its changed behavior, compile with `-d:nimOldOrc`.
-- The `gc:orc` algorithm was refined so that custom container types can participate in the
+- The `--gc:orc` algorithm was refined so that custom container types can participate in the
   cycle collection process. See the documentation of `=trace` for more details.
 - On embedded devices `malloc` can now be used instead of `mmap` via `-d:nimAllocPagesViaMalloc`.
   This is only supported for `--gc:orc` or `--gc:arc`.
@@ -746,9 +745,9 @@ Compatibility notes:
 
 
 ## Docgen
-- docgen: rst files can now use single backticks instead of double backticks and correctly render
-  in both rst2html (as before) as well as common tools rendering rst directly (e.g. github), by
-  adding: `default-role:: code` directive inside the rst file, which is now handled by rst2html.
+- docgen: RST files can now use single backticks instead of double backticks and correctly render
+  in both `rst2html` (as before) as well as common tools rendering RST directly (e.g. GitHub), by
+  adding: `default-role:: code` directive inside the RST file, which is now handled by `rst2html`.
 
 - Source+Edit links now appear on top of every docgen'd page when
   `nim doc --git.url:url ...` is given.
@@ -757,8 +756,8 @@ Compatibility notes:
   by `xelatex` (not by `pdflatex` as before). Now default Latex settings
   provide support for Unicode and do better job for avoiding margin overflows.
 
-- The rst parser now supports footnotes, citations, admonitions, short style references with symbols.
-- The rst parser now supports markdown table syntax.
+- The RST parser now supports footnotes, citations, admonitions, short style references with symbols.
+- The RST parser now supports Markdown table syntax.
   Known limitations:
   - cell alignment is not supported, i.e. alignment annotations in a delimiter
     row (`:---`, `:--:`, `---:`) are ignored,
@@ -785,22 +784,23 @@ func fn*(a: int): int = 42  ## Doc comment
 
 - There is a new `cast` section `{.cast(uncheckedAssign).}: body` that disables some
   compiler checks regarding `case objects`. This allows serialization libraries
-  to avoid ugly, non-portable solutions. See https://github.com/nim-lang/RFCs/issues/407
+  to avoid ugly, non-portable solutions. See RFC [#407](https://github.com/nim-lang/RFCs/issues/407).
   for more details.
 
 ## Tools
-- major improvements to `nimgrep`, see PR #15612.
-- `fusion` is now un-bundled from nim, `./koch fusion` will
-  install it via nimble at a fixed hash.
+- major improvements to `nimgrep`, see PR [#15612
+](https://github.com/nim-lang/Nim/pull/15612).
+- `fusion` is now un-bundled from Nim, `./koch fusion` will
+  install it via Nimble at a fixed hash.
 
-- testament: added `nimoutFull: bool` spec to compare full output of compiler
+- `testament`: added `nimoutFull: bool` spec to compare full output of compiler
   instead of a subset; many bugfixes to testament.
 
-- Added atlas helper tool.
+- Added `atlas` helper tool.
 
 ## Misc/cleanups
 - Deprecated `TaintedString` and `--taintmode`.
 - Deprecated `--nilseqs` which is now a noop.
 - Added `-d:nimStrictMode` in CI in several places to ensure code doesn't have certain hints/warnings
 - Removed `.travis.yml`, `appveyor.yml.disabled`, `.github/workflows/ci.yml.disabled`.
-- `[skip ci]` now works in azure and CI pipelines, see detail in PR #17561
+- `[skip ci]` now works in azure and CI pipelines, see detail in PR [#17561](https://github.com/nim-lang/Nim/pull/17561)

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -570,8 +570,8 @@ Compatibility notes:
 - Empty environment variable values are now supported across OS's and backends.
 - Environment variable APIs now work in multithreaded scenarios, by delegating to direct OS calls
   instead of trying to keep track of the environment.
-- `putEnv`, `delEnv` now work at CT.
-- NodeJS backend now supports osenv: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
+- NodeJS backend now supports `osenv`: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
+- `osenv` now works in all backends (c,cpp,vm,nims,js with -d:nodejs), see PR [#18615](https://github.com/nim-lang/Nim/pull/18615).
 
 Compatibility notes:
 - `std/os`: `putEnv` now raises if the first argument contains a `=`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -19,7 +19,7 @@ last year it entered the top-100, and in the last 2 months the top-50 ([https://
 We hope this release will reinforce this trend, building on Nim's core strengths:
 a practical, compiled systems programming language; offering C-like performance and portability;
 Python-like syntax; Lisp-like flexibility; strong C, C++, JS, Python interop;
-and best-in class metaprogramming.
+and best-in-class metaprogramming.
 
 Why use Nim?
 * one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum), [scientific computing](https://github.com/SciNim), [machine learning](https://github.com/mratsim/Arraymancer), [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico), [embedded](https://github.com/EmbeddedNim).
@@ -92,7 +92,7 @@ in fact all the existing CI pipelines have been refactored to use this, see
 
 # Contributors to Nim 1.6
 
-Many thanks to our recurring and new [contributors](https://github.com/nim-lang/Nim/graphs/contributors?from=2020-10-16&to=2021-09-25&type=c),
+Many thanks to our recurring and new [contributors](https://github.com/nim-lang/Nim/graphs/contributors?from=2020-10-16&to=2021-09-25&type=c).
 Nim is a community driven collaborative effort that welcomes all contributions, big or small.
 
 
@@ -101,11 +101,11 @@ Nim is a community driven collaborative effort that welcomes all contributions, 
 Starting with this release, we've introduced preview flags of the form `-d:nimPreviewX`
 (e.g. `-d:nimPreviewFloatRoundtrip`), which allow users to opt-in to new stdlib/compiler behavior
 that will likely become the default in the next or a future release.
-These staging flags are aimed at minimizing backward compatibility issues.
+These staging flags aim to minimize backward compatibility issues.
 
 We also introduced opt-out flags of the form `-d:nimLegacyX`,  e.g. `-d:nimLegacyCopyFile`,
 for cases where the default was changed to the new behavior.
-For a transition period, these flags can be used to get the old behaviour.
+For a transition period, these flags can be used to get the old behavior.
 
 Here's the list of these flags introduced in this release, refer to the text below for explanations:
 - `-d:nimLegacyCopyFile`
@@ -153,7 +153,7 @@ template sum[T](a: iterable[T]): T =
 assert sum(iota(3)) == 0 + 1 + 2 # or `iota(3).sum`
 
 ```
-In particular iterable arguments can now be used with MCS, example:
+In particular iterable arguments can now be used with the method call syntax. For example:
 ```nim
 import std/[sequtils, os]
 echo walkFiles("*").toSeq # now works
@@ -179,7 +179,7 @@ To enable the new effect system, compile with `--experimental:strictEffects`. Se
 
 
 ## Private imports and private field access
-A new import syntax `import foo {.all.}` now allows to import all symbols (public or private) from `foo`.
+A new import syntax `import foo {.all.}` now allows importing all symbols (public or private) from `foo`.
 This can be useful for testing purposes or for more flexibility in project organization.
 
 Example:
@@ -295,7 +295,7 @@ With `-d:nimPreviewDotLikeOps`, dot-like operators (operators starting with `.`,
 now have the same precedence as `.`, so that `a.?b.c` is now parsed as `(a.?b).c` instead of `a.?(b.c)`.
 A warning is generated when a dot-like operator is used without `-d:nimPreviewDotLikeOps`.
 
-An important use case is to enable dynamic fields without affecting the builtin `.` operator, e.g. for
+An important use case is to enable dynamic fields without affecting the built-in `.` operator, e.g. for
 `std/jsffi`, `std/json`, `pkg/nimpy`. Example:
 ```nim
 import std/json
@@ -346,7 +346,7 @@ The following modules were added (they are discussed in the rest of the text):
 - `std/vmutils`
 
 - Deprecated `std/mersenne`.
-- Removed deprecated `std/iup` module from stdlib, it has already moved to
+- Removed deprecated `std/iup` module from stdlib; it has already moved to
   [nimble](https://github.com/nim-lang/iup).
 
 
@@ -362,7 +362,7 @@ The following modules were added (they are discussed in the rest of the text):
 - Added `genEnumCaseStmt` macro that generates
   case statement to parse string to enum.
 - Added `items` for enums with holes.
-- Added `symbolName` to return the `enum` symbol name ignoring the human readable name.
+- Added `symbolName` to return the `enum` symbol name ignoring the human-readable name.
 - Added `symbolRank` to return the index in which an `enum` member is listed in an enum.
 
 
@@ -382,7 +382,7 @@ Compatibility notes:
   that an index error is produced instead. Be aware however that your code might depend on
   this quirky behavior so a review process is required on your part before you can
   use `-d:nimStrictDelete`. To make this review easier, use the `-d:nimAuditDelete`
-  switch, it pretends that `system.delete` is deprecated so that it is easier to see
+  switch, which pretends that `system.delete` is deprecated so that it is easier to see
   where it was used in your code.
   `-d:nimStrictDelete` will become the default in upcoming versions.
 - `cuchar` is now deprecated as it aliased `char` where arguably it should have aliased `uint8`.
@@ -397,7 +397,7 @@ Compatibility notes:
 ## `std/math`
 - Added `almostEqual` for comparing two float values using a machine epsilon.
 - Added `clamp` which allows using a `Slice` to clamp to a value.
-- Added `ceilDiv` for round up integer division.
+- Added `ceilDiv` for integer division that rounds up.
 - Added `isNaN`.
 - Added `copySign`.
 - Added `euclDiv` and `euclMod`.
@@ -421,7 +421,7 @@ Compatibility notes:
 
 Compatibility notes:
 - Deprecated `std/mersenne`.
-- `random.initRand(seed)` now produces non-skewed values for the 1st call to `rand()` after
+- `random.initRand(seed)` now produces non-skewed values for the first call to `rand()` after
   initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
   previous behavior for a transition time, see PR [#17467](https://github.com/nim-lang/Nim/pull/17467).
 
@@ -429,8 +429,8 @@ Compatibility notes:
 ## `std/json`, `std/jsonutils`
 - `std/jsonutils` now serializes/deserializes holey enums as regular enums (via `ord`) instead of as strings.
   Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period. `toJson` now serializes `JsonNode`
-  as is via reference (without a deep copy) instead of treating `JsonNode` as a regular ref object,
-  this can be customized via `jsonNodeMode`.
+  as-is via reference (without a deep copy) instead of treating `JsonNode` as a regular ref object.
+  This can be customized via `jsonNodeMode`.
 - `std/json` and `std/jsonutils` now serialize `NaN`, `Inf`, `-Inf` as strings, so that
   `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid JSON.
 - `std/json` can now handle integer literals and floating point literals of
@@ -442,10 +442,10 @@ Compatibility notes:
   literals remain in the "raw" string form so that client code can easily treat
   small and large numbers uniformly.
 - Added `BackwardsIndex` overload for `JsonNode`.
-- `json.%`,`json.to`, `jsonutils.formJson`,`jsonutils.toJson` now work with `uint|uint64`
+- `json.%`,`json.to`, `jsonutils.fromJson`,`jsonutils.toJson` now work with `uint|uint64`
   instead of raising (as in 1.4) or giving wrong results (as in 1.2).
 - `std/jsonutils` now handles `cstring` (including as Table key), and `set`.
-- added `jsonutils.jsonTo` overload with `opt = Joptions()` param.
+- Added `jsonutils.jsonTo` overload with `opt = Joptions()` param.
 - `jsonutils.toJson` now supports customization via `ToJsonOptions`.
 - `std/json`, `std/jsonutils` now support round-trip serialization when `-d:nimPreviewFloatRoundtrip` is used.
 
@@ -464,7 +464,7 @@ Compatibility notes:
 - Fixed buffer overflow bugs in `std/net`.
 - Exported `sslHandle` from `std/net` and `std/asyncnet`.
 - Added `hasDataBuffered` to `std/asyncnet`.
-- Various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover `request` function's
+- Various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover, the `request` function's
   `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` `enum` type; see [#15919](https://github.com/nim-lang/Nim/pull/15919).
 - Added `asyncdispatch.activeDescriptors` that returns the number of currently
   active async event handles/file descriptors.
@@ -476,7 +476,7 @@ Compatibility notes:
 
 Compatibility notes:
 - On Windows, the SSL library now checks for valid certificates.
-  It uses the `cacert.pem` file for this purpose which was extracted
+  For this purpose it uses the `cacert.pem` file, which was extracted
   from `https://curl.se/ca/cacert.pem`. Besides
   the OpenSSL DLLs (e.g. `libssl-1_1-x64.dll`, `libcrypto-1_1-x64.dll`) you
   now also need to ship `cacert.pem` with your `.exe` file.
@@ -485,7 +485,7 @@ Compatibility notes:
 ## `std/hashes`
 - `hashes.hash` can now support `object` and `ref` (can be overloaded in user code),
   if `-d:nimEnableHashRef` is used.
-- `hashes.hash(proc|ptr|ref|pointer)` now calls `hash(int)` and honors `-d:nimIntHash1`,
+- `hashes.hash(proc|ptr|ref|pointer)` now calls `hash(int)` and honors `-d:nimIntHash1`.
   `hashes.hash(closure)` has also been improved.
 
 
@@ -512,14 +512,14 @@ Compatibility notes:
 
 
 ## Environment variable handling
-- empty environment variable values are now supported across OS's and backends.
-- environment variable APIs now work in multithreaded scenarios, by delegating to direct OS calls
+- Empty environment variable values are now supported across OS's and backends.
+- Environment variable APIs now work in multithreaded scenarios, by delegating to direct OS calls
   instead of trying to keep track of the environment.
 - `putEnv`, `delEnv` now work at CT.
 - NodeJS backend now supports osenv: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
 
 Compatibility notes:
-- `std/os`: `putEnv` now raises if the 1st argument contains a `=`.
+- `std/os`: `putEnv` now raises if the first argument contains a `=`.
 
 
 ## POSIX
@@ -545,8 +545,8 @@ Compatibility notes:
 
 ## String manipulation: `std/strformat`, `std/strbasics`
 - Added support for parenthesized expressions.
-- Added support for const string's instead of just string literals.
-- Added `std/strbasics` for high performance string operations.
+- Added support for const strings instead of just string literals.
+- Added `std/strbasics` for high-performance string operations.
 - Added `strip`, `setSlice`, `add(a: var string, b: openArray[char])`.
 
 
@@ -598,7 +598,7 @@ Compatibility notes:
 - Tuple expressions are now parsed consistently as
   `nnkTupleConstr` node. Will affect macros expecting nodes to be of `nnkPar`.
 - In `std/macros`, `treeRepr,lispRepr,astGenRepr` now represent SymChoice nodes in a collapsed way.
-- Make custom op in `macros.quote` work for all statements.
+- Made custom op in `macros.quote` work for all statements.
 
 
 ## `std/sugar`
@@ -613,7 +613,7 @@ Compatibility notes:
 ## Parsing: `std/parsecfg`, `std/strscans`, `std/uri`
 - Added `sections` iterator in `parsecfg`.
 - `strscans.scanf` now supports parsing single characters.
-- `strscans.scanTuple` added which uses `strscans.scanf` internally,
+- Added `strscans.scanTuple` which uses `strscans.scanf` internally,
   returning a tuple which can be unpacked for easier usage of `scanf`.
 - Added `decodeQuery` to `std/uri`.
 - `parseopt.initOptParser` has been made available and `parseopt` has been
@@ -627,14 +627,14 @@ Compatibility notes:
 Compatibility notes:
 - Changed the behavior of `uri.decodeQuery` when there are unencoded `=`
   characters in the decoded values. Prior versions would raise an error. This is
-  no longer the case to comply with the HTML spec and other languages
+  no longer the case to comply with the HTML spec and other languages'
   implementations. Old behavior can be obtained with
   `-d:nimLegacyParseQueryStrict`. `cgi.decodeData` which uses the same
   underlying code is also updated the same way.
 
 
 ## JS stdlib changes
-- Added `std/jsbigints` module, arbitrary precision integers for the JS target.
+- Added `std/jsbigints` module, which provides arbitrary precision integers for the JS target.
 - Added `setCurrentException` for the JS backend.
 - `writeStackTrace` is available in the JS backend now.
 - Added `then`, `catch` to `std/asyncjs` for promise pipelining, for now hidden behind `-d:nimExperimentalAsyncjsThen`.
@@ -652,7 +652,7 @@ Compatibility notes:
 - Added `dom.scrollIntoView` proc with options.
 - Added `dom.setInterval`, `dom.clearInterval` overloads.
 - Merged `std/dom_extensions` into the `std/dom` module,
-  it was a module with a single line, see RFC [#413](https://github.com/nim-lang/RFCs/issues/413).
+  as it was a module with a single line, see RFC [#413](https://github.com/nim-lang/RFCs/issues/413).
 - `$` now gives more correct results on the JS backend.
 
 
@@ -679,11 +679,12 @@ Compatibility notes:
 - Support for armv8l, refs [#18901](https://github.com/nim-lang/Nim/pull/18901).
 - Support for CROSSOS, refs [#18889](https://github.com/nim-lang/Nim/pull/18889).
 - The allocator for Nintendo Switch, which was nonfunctional because
-  of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
+  of breaking changes in libnx, was removed, in favor of the new `-d:nimAllocPagesViaMalloc` option.
 - Allow reading parameters when compiling for Nintendo Switch.
-- Cross compilation targeting Windows was improved
-  This now works from macOS/Linux:
-  `nim r -d:mingw main`
+- Cross compilation targeting Windows was improved.
+
+  This now works from macOS/Linux: `nim r -d:mingw main`
+  
   `--nimcache` now correctly works in a cross-compilation setting.
 
 
@@ -801,7 +802,7 @@ Compatibility notes:
 
 
 ## Multithreading
-- TLS: macOS now uses native TLS (`--tlsEmulation:off`), TLS now works with `importcpp` non-POD types,
+- TLS: macOS now uses native TLS (`--tlsEmulation:off`). TLS now works with `importcpp` non-POD types;
   such types must use `.cppNonPod` and `--tlsEmulation:off`should be used.
 - Added `unsafeIsolate` and `extract` to `std/isolation`.
 - Added `std/tasks`, a new module containing primitives for creating parallel programs.
@@ -830,21 +831,21 @@ Compatibility notes:
   `nim doc --git.url:url ...` is given.
 - Latex doc generation is revised: output `.tex` files should be compiled
   by `xelatex` (not by `pdflatex` as before). Now default Latex settings
-  provide support for Unicode and do better job for avoiding margin overflows.
-- The RST parser now supports footnotes, citations, admonitions, short style references with symbols.
+  provide support for Unicode and better avoid margin overflows.
+- The RST parser now supports footnotes, citations, admonitions, and short style references with symbols.
 - The RST parser now supports Markdown table syntax.
   Known limitations:
   - cell alignment is not supported, i.e. alignment annotations in a delimiter
-    row (`:---`, `:--:`, `---:`) are ignored,
+    row (`:---`, `:--:`, `---:`) are ignored
   - every table row must start with `|`, e.g. `| cell 1 | cell 2 |`.
 - Implemented `doc2tex` compiler command which converts documentation in
   `.nim` files to Latex.
 - docgen now supports syntax highlighting for inline code.
-- docgen now supports same line doc comments:
+- docgen now supports same-line doc comments:
 ```nim
 func fn*(a: int): int = 42  ## Doc comment
 ```
-- docgen now renders deprecated and other pragmas.
+- docgen now renders `deprecated` and other pragmas.
 - `runnableExamples` now works with templates and nested templates.
 - `runnableExamples: "-r:off"` now works for examples that should compile but not run. 
 - `runnableExamples` now renders code verbatim, and produces correct code in all cases.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -21,7 +21,7 @@ This release includes improvements in the following areas:
 * correctness and performance of integer and float parsing and rendering in all backends
 * significant improvements in error messages, showing useful context
 * doc generation logic and documentation, in particular `runnableExamples` now works in more contexts and replaces `code-block`.
-* made JS, VM and nimscript backend more consistent with C backend, allowing more modules to work with those backends, including the imports from `prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
+* made JS, VM and nimscript backend more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
 * support for apple silicon/M1 macs, 32-bit RISC-V, improved support for nodejs backend
 * major improvements to the following modules: `system, math, random, json, jsonutils, os, typetraits, wrapnils, lists, hashes` including performance improvements
 * deprecated a number of error prone or redundant mis-features

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -283,7 +283,7 @@ fn(1, 2): # already works
 fn(a = 1): # now works
   bar
 ```
-ditto with multiple block arguments via `do`:
+Likewise with multiple block arguments via `do`:
 ```nim
 template fn(a = 1, b = 2, body1, body2) = discard
 fn(a = 1): # now works
@@ -764,7 +764,7 @@ Compatibility notes:
   nim r main # recompiles
   nim r -d:foo main # recompiles
   nim r main # uses cached binary
-  nim r main arg1 arg2 # ditto (runtime arguments are irrelevant)
+  nim r main arg1 arg2 # likewise (runtime arguments are irrelevant)
 ```
 
 - `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using Wine,

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -3,8 +3,11 @@ title: "Version 1.6.0 released"
 author: The Nim Team
 ---
 
-We are very proud to announce Nim version 1.6, the latest stable release, after a year in the making!
-This is by far the biggest release yet, here are some stats:
+Nim version 1.6 is now officially released!
+
+A year in the making, 1.6 is the latest stable release and by far the largest yet.
+We're proud of what we, the core team and dedicated volunteers, have accomplished with this milestone.
+Here are some stats:
 * 1667 PRs merged (1760 commits)
 * 893 issues closed
 * 15 new stdlib modules

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -30,7 +30,7 @@ This release includes improvements in the following areas:
 * significant improvements in error messages, showing useful context
 * documentation generation logic and documentation, in particular `runnableExamples` now works in more contexts
 * JS, VM and nimscript backend are more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
-* support for Apple silicon/M1, 32-bit RISC-V, CROSSOS, improved support for NodeJS backend
+* support for Apple silicon/M1, 32-bit RISC-V, armv8l, CROSSOS, improved support for NodeJS backend
 * major improvements to the following modules: `system`, `math`, `random`, `json`, `jsonutils`, `os`, `typetraits`, `wrapnils`, `lists`, `hashes` including performance improvements
 * deprecated a number of error prone or redundant mis-features
 
@@ -623,6 +623,7 @@ Compatibility notes:
 ## OS-specific notes
 - Support for Apple silicon/M1.
 - Support for 32-bit RISC-V, refs [#16231](https://github.com/nim-lang/Nim/pull/16231).
+- Support for armv8l, refs [#18901](https://github.com/nim-lang/Nim/pull/18901).
 - Support for CROSSOS, refs [#18889](https://github.com/nim-lang/Nim/pull/18889).
 - The allocator for Nintendo Switch, which was nonfunctional because
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -881,8 +881,8 @@ func fn*(a: int): int = 42  ## Doc comment
 Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
 * [1] command used: `nim c -o:/tmp/main -d:danger --eval:'echo "hello world"'`
 * [2] commands used:
-  for nim: `nim c --forceBuild compiler/nim`
-  for rust: `./x.py build`, see also https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/
+  for Nim: `nim c --forceBuild compiler/nim`
+  for Rust: `./x.py build`, see also https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/
   for GCC: see https://unix.stackexchange.com/questions/421822/how-long-does-it-take-to-compile-gcc-7-3-0
   https://solarianprogrammer.com/2016/10/07/building-gcc-ubuntu-linux/
   for Clang: see https://quuxplusone.github.io/blog/2018/04/16/building-llvm-from-source/

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -22,7 +22,7 @@ Python-like syntax; Lisp-like flexibility; strong C, C++, JS, Python interop;
 and best-in class metaprogramming.
 
 Why use Nim?
-* one language to rule them all: write your iOS/Android/web frontend and backend in the same language, from a [Gameboy kickstarter](https://forum.nim-lang.org/t/8375) to a [blockchain client](https://github.com/status-im).
+* one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum), [scientific computing](https://github.com/SciNim), [machine learning](https://github.com/mratsim/Arraymancer), [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico), [embedded](https://github.com/EmbeddedNim).
 * concise and readable like Python: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
 * small binaries: `echo "hello world"` generates a 73K binary (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -139,7 +139,7 @@ See PR [#15687](https://github.com/nim-lang/Nim/pull/15687) for more details.
 
 
 ## Round-trip float to string
-`system.addFloat` and `system.$` now can produce string representations of floating point numbers that are minimal in size and that "round-trip" (via the "Dragonbox" algorithm).
+`system.addFloat` and `system.$` now can produce string representations of floating point numbers that are minimal in size and possess round-trip and correct rounding guarantees (via the [Dragonbox](https://raw.githubusercontent.com/jk-jeon/dragonbox/master/other_files/Dragonbox.pdf) algorithm).
 This currently has to be enabled via `-d:nimPreviewFloatRoundtrip`.
 It is expected that this behavior becomes the new default in upcoming versions, as with other `nimPreviewX` define flags.
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -265,7 +265,7 @@ The following modules were added (they are discussed in the rest of the text):
 - `std/vmutils`
 
 - Deprecated `std/mersenne`.
-- Removed deprecated `iup` module from stdlib, it has already moved to
+- Removed deprecated `std/iup` module from stdlib, it has already moved to
   [nimble](https://github.com/nim-lang/iup).
 
 
@@ -354,7 +354,7 @@ Compatibility notes:
   this can be customized via `jsonNodeMode`.
 - `json` and `jsonutils` now serialize NaN, Inf, -Inf as strings, so that
   `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid json.
-- The JSON module can now handle integer literals and floating point literals of
+- `std/json` can now handle integer literals and floating point literals of
   arbitrary length and precision.
   Numbers that do not fit the underlying `BiggestInt` or `BiggestFloat` fields are
   kept as string literals and one can use external BigNum libraries to handle these.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -886,6 +886,6 @@ Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
   for GCC: see https://unix.stackexchange.com/questions/421822/how-long-does-it-take-to-compile-gcc-7-3-0
   https://solarianprogrammer.com/2016/10/07/building-gcc-ubuntu-linux/
   for Clang: see https://quuxplusone.github.io/blog/2018/04/16/building-llvm-from-source/
-  for go: `./make.bash`
+  for Go: `./make.bash`
 * [3] a separate nimscript file can be used if needed to execute code at compile time
       before compiling the main program but it's in the same language

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -319,7 +319,7 @@ The following modules were added (they are discussed in the rest of the text):
   with most other languages.
 - Added `cmpMem` to `system`.
 - `doAssertRaises` now correctly handles foreign exceptions.
-- `addInt` now supports unsigned integers
+- `addInt` now supports unsigned integers.
 
 Compatibility notes:
 - `system.delete` had a most surprising behavior when the index passed to it was out of

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -233,12 +233,14 @@ echo 0xdeadbeef'big shl 4'big # 59774856944n
 
 
 ## New `std/sysrand` module
-Cryptographically secure pseudorandom number generator, see PR [#16459](https://github.com/nim-lang/Nim/pull/16459).
+Cryptographically secure pseudorandom number generator,
+allows generating random numbers from a secure source provided by the operating system.
 Example:
 ```nim
 import std/sysrand
 assert urandom(1234) != urandom(1234) # unlikely to fail in practice
 ```
+See PR [#16459](https://github.com/nim-lang/Nim/pull/16459).
 
 
 ## New module: `std/tempfiles`
@@ -392,11 +394,11 @@ Compatibility notes:
 
 
 ## Random number generators: `std/random`, `std/sysrand`, `std/oids`
+- Added `std/sysrand` module (see details above).
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 - Added `initRand()` overload with no argument which uses the current time as a seed.
 - `initRand(seed)` now allows `seed == 0`.
-- Added `std/sysrand` module to get random numbers from a secure source.
 - Fixed overflow bugs.
 - Fix `initRand` to avoid random number sequences overlapping, refs [#18744](https://github.com/nim-lang/Nim/pull/18744).
 - `std/oids` now uses `std/random`.
@@ -406,7 +408,6 @@ Compatibility notes:
 - `random.initRand(seed)` now produces non-skewed values for the 1st call to `rand()` after
   initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
   previous behavior for a transition time, see PR [#17467](https://github.com/nim-lang/Nim/pull/17467).
-  provided by the operating system.
 
 
 ## `std/json`, `std/jsonutils`

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -6,8 +6,7 @@ author: The Nim Team
 Nim version 1.6 is now officially released!
 
 A year in the making, 1.6 is the latest stable release and by far the largest yet.
-We're proud of what we, the core team and dedicated volunteers, have accomplished with this milestone.
-Here are some stats:
+We're proud of what we, the core team and dedicated volunteers, have accomplished with this milestone:
 * 1667 PRs merged (1760 commits)
 * 893 issues closed
 * 15 new stdlib modules
@@ -21,6 +20,22 @@ We hope this release will reinforce this trend, building on Nim's core strengths
 a practical, compiled systems programming language; offering C-like performance and portability;
 Python-like syntax; LISP-like flexibility; strong C, C++, JS, Python interop;
 and best-in class metaprogramming.
+
+Why use Nim?
+* one language to rule them all: write your iOS/android/web frontend and backend in the same language, from a [gameboy kickstarter](https://forum.nim-lang.org/t/8375) to a [blockchain client](https://github.com/status-im).
+* concise and readable like python: `echo "hello world"` is a 1-liner (5 lines in C, C++, go, java).
+* small binaries: `echo "hello world"` generates a 73K binary (go: 2MB, rust: 377K, C++: 56K), thanks to dead code elimination [1].
+* good compile times: a full compiler rebuild takes ~12s (rust: 15mn, gcc: 30mn+, clang: 1hr+, go: 90s) [2].
+* no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
+* target any platform where there's a C compiler [4], from embedded devices to WASM to nintendo or gameboy
+* 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, python (via [nimpy](https://github.com/yglukhov/nimpy))
+* built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands nim code and runnable examples that stay in sync
+
+Last but not least, `macros` let you manipulate/generate code at compile time instead of relying on code generators, allowing for example to easily write DSLs or extend the language, all in user code:
+  - [karax](https://github.com/karaxnim/karax) for react+JSX-like Single Page Applications
+  - [cligen](https://github.com/c-blake/cligen) for API-inferred command line generator
+  - [std/wrapnils](https://nim-lang.github.io/Nim/wrapnils.html) JS-like optional chaining
+  - [std/strformat](https://nim-lang.github.io/Nim/strformat.html) python-like f-strings
 
 This release includes improvements in the following areas:
 * new language features (`iterable[T]`, user-defined literals, private imports, strict effects, dot-like operators, block arguments with optional parameters)
@@ -859,3 +874,17 @@ func fn*(a: int): int = 42  ## Doc comment
 - Added `-d:nimStrictMode` in CI in several places to ensure code doesn't have certain hints/warnings.
 - Removed `.travis.yml`, `appveyor.yml.disabled`, `.github/workflows/ci.yml.disabled`.
 - `[skip ci]` now works in azure and CI pipelines, see detail in PR [#17561](https://github.com/nim-lang/Nim/pull/17561).
+
+
+# Footnotes
+Evaluated on a 8-core 2019 mac 11.5, 2.3GHz with 64GB RAM.
+* [1] command used: `nim c -o:/tmp/main -d:danger --eval:'echo "hello world"'`
+* [2] commands used:
+  for nim: `nim c --forceBuild compiler/nim`
+  for rust: `./x.py build`, see also https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/
+  for gcc: see https://unix.stackexchange.com/questions/421822/how-long-does-it-take-to-compile-gcc-7-3-0
+  https://solarianprogrammer.com/2016/10/07/building-gcc-ubuntu-linux/
+  for clang: see https://quuxplusone.github.io/blog/2018/04/16/building-llvm-from-source/
+  for go: `./make.bash`
+* [3] a separate nimscript file can be used if needed to execute code at compile time
+      before compiling the main program but it's in the same language

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -487,7 +487,7 @@ Compatibility notes:
 ## Containers: `std/algorithm`, `std/lists`, `std/sequtils`, `std/options`, `std/packedsets`
 - Removed the optional `longestMatch` parameter of the `critbits._WithPrefix` iterators (it never worked reliably)
 - Added `algorithm.merge`.
-- In `lists`: renamed `append` to `add` and retained `append` as an alias;
+- In `std/lists`: renamed `append` to `add` and retained `append` as an alias;
   added `prepend` and `prependMoved` analogously to `add` and `addMoved`;
   added `remove` for `SinglyLinkedList`s.
 - Added new operations for singly- and doubly linked lists: `lists.toSinglyLinkedList`
@@ -524,7 +524,7 @@ Compatibility notes:
   `nnkTupleConstr` node. Will affect macros expecting nodes to be of `nnkPar`.
 - In `std/macros`, `treeRepr,lispRepr,astGenRepr` now represent SymChoice nodes in a collapsed way,
 
-- Make custom op in macros.quote work for all statements.
+- Make custom op in `macros.quote` work for all statements.
 
 
 ## `std/sugar`
@@ -560,7 +560,7 @@ Compatibility notes:
 
 
 ## JS stdlib changes
-- Added `jsbigints` module, arbitrary precision integers for JS target.
+- Added `std/jsbigints` module, arbitrary precision integers for JS target.
 - Added setCurrentException for JS backend.
 - `writeStackTrace` is available in JS backend now.
 - Added `then`, `catch` to `asyncjs` for promise pipelining, for now hidden behind `-d:nimExperimentalAsyncjsThen`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -17,9 +17,9 @@ Here are some stats:
 
 Nim made its first entry in TIOBE index in 2017 at position 129,
 last year it entered the top-100, and last 2 months it entered the top-50 (https://forum.nim-lang.org/t/8297).
-We hope this release will reinforce this trend, building on Nim's core strenghs:
+We hope this release will reinforce this trend, building on Nim's core strengths:
 a practical, compiled systems programming language; offering C-like performance and portability;
-Python-like syntax; LISP-like flexibility; strong C, C++, JS, python interop;
+Python-like syntax; LISP-like flexibility; strong C, C++, JS, Python interop;
 and best-in class metaprogramming.
 
 This release includes improvements in the following areas:
@@ -753,7 +753,7 @@ Compatibility notes:
 
 Compatibility notes:
 - `--newruntime` and `--refchecks` are deprecated,
-  use `--gc:arc`, --gc:orc`, or `--gc:none` as appropriate instead.
+  use `--gc:arc`, `--gc:orc`, or `--gc:none` as appropriate instead.
 
 
 ## Docgen
@@ -808,7 +808,7 @@ func fn*(a: int): int = 42  ## Doc comment
 - `testament`: added `nimoutFull: bool` spec to compare full output of compiler
   instead of a subset; many bugfixes to testament.
 
-- Added `atlas` a tool for automating workflows involing "cloning" a nimble package and dependencies recursively
+- Added `atlas` a tool for automating workflows involving "cloning" a nimble package and dependencies recursively
 
 ## Misc/cleanups
 - Deprecated `TaintedString` and `--taintmode`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -736,7 +736,9 @@ type
   Comparable = concept # no T, an atom
     proc cmp(a, b: Self): int
 ```
-See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
+The new design does not rely on `system.compiles` and may compile faster.
+See PR [#15251](https://github.com/nim-lang/Nim/pull/15251)
+and RFC [#168](https://github.com/nim-lang/RFCs/issues/168) for details.
 
 
 ## Lexical / syntactic

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -152,7 +152,7 @@ echo a # with `-d:nimPreviewFloatRoundtrip`: 9.78, like in python3 (instead of  
 ```
 
 ## New `std/jsbigints` module
-Provides arbitrary precision integers for JS target. See PR #16409.
+Provides arbitrary precision integers for JS target. See PR [#16409](https://github.com/nim-lang/Nim/pull/16409).
 Example:
 ```nim
 import std/jsbigints
@@ -385,7 +385,7 @@ Compatibility notes:
 - Exported `sslHandle` from `std/net` and `std/asyncnet`.
 - Added `hasDataBuffered` to `std/asyncnet`.
 - various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover `request` function's
-  `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` `enum` type; see #15919.
+  `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` `enum` type; see [#15919](https://github.com/nim-lang/Nim/pull/15919).
 - Added `asyncdispatch.activeDescriptors` that returns the number of currently
   active async event handles/file descriptors.
 - Added `getPort` to `std/asynchttpserver` to resolve OS-assigned `Port(0)`;
@@ -496,7 +496,7 @@ Compatibility notes:
   See PR [#16362](https://github.com/nim-lang/Nim/pull/16362), [#16536](https://github.com/nim-lang/Nim/pull/16536).
 
 - new module: `std/packedsets`
-  Generalizes `std/intsets`, see PR #15564.
+  Generalizes `std/intsets`, see PR [#15564](https://github.com/nim-lang/Nim/pull/15564).
 
 Compatibility notes:
 - Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -348,11 +348,11 @@ Compatibility notes:
 
 
 ## `std/json`, `std/jsonutils`
-- `jsonutils` now serializes/deserializes holey enums as regular enums (via `ord`) instead of as strings.
+- `std/jsonutils` now serializes/deserializes holey enums as regular enums (via `ord`) instead of as strings.
   Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period. `toJson` now serializes `JsonNode`
   as is via reference (without a deep copy) instead of treating `JsonNode` as a regular ref object,
   this can be customized via `jsonNodeMode`.
-- `json` and `jsonutils` now serialize NaN, Inf, -Inf as strings, so that
+- `std/json` and `std/jsonutils` now serialize NaN, Inf, -Inf as strings, so that
   `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid json.
 - `std/json` can now handle integer literals and floating point literals of
   arbitrary length and precision.
@@ -365,10 +365,10 @@ Compatibility notes:
 - Added `BackwardsIndex` overload for `JsonNode`.
 - `json.%`,`json.to`, `jsonutils.formJson`,`jsonutils.toJson` now work with `uint|uint64`
   instead of raising (as in 1.4) or giving wrong results (as in 1.2).
-- `jsonutils` now handles `cstring` (including as Table key), and `set`.
+- `std/jsonutils` now handles `cstring` (including as Table key), and `set`.
 - added `jsonutils.jsonTo` overload with `opt = Joptions()` param.
 - `jsonutils.toJson` now supports customization via `ToJsonOptions`.
-- `json`, `jsonutils` now support round-trip serialization when `-d:nimPreviewFloatRoundtrip` is used.
+- `std/json`, `std/jsonutils` now support round-trip serialization when `-d:nimPreviewFloatRoundtrip` is used.
 
 
 ## `std/typetraits`, `std/compilesettings`
@@ -382,16 +382,16 @@ Compatibility notes:
 
 
 ## networking: `std/net`, `std/asyncnet`, `std/htmlgen`, `std/httpclient`, `std/asyncdispatch`, `std/asynchttpserver`, `std/httpcore`
-- Fixed buffer overflow bugs in `net`.
-- Exported `sslHandle` from `net` and `asyncnet`.
-- Added `hasDataBuffered` to `asyncnet`.
-- various functions in `httpclient` now accept `url` of type `Uri`. Moreover `request` function's
+- Fixed buffer overflow bugs in `std/net`.
+- Exported `sslHandle` from `std/net` and `std/asyncnet`.
+- Added `hasDataBuffered` to `std/asyncnet`.
+- various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover `request` function's
   `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` enum type; see #15919.
 - Added `asyncdispatch.activeDescriptors` that returns the number of currently
   active async event handles/file descriptors.
-- Added `getPort` to `asynchttpserver` to resolve OS-assigned `Port(0)`;
+- Added `getPort` to `std/asynchttpserver` to resolve OS-assigned `Port(0)`;
   this is usually recommended instead of hardcoding ports which can lead to "Address already in use" errors.
-- Fixed premature garbage collection in asyncdispatch, when a stack trace override is in place.
+- Fixed premature garbage collection in `std/asyncdispatch`, when a stack trace override is in place.
 - Added `httpcore.is1xx` and missing HTTP codes.
 - Added `htmlgen.portal` for [making "SPA style" pages using HTML only](https://web.dev/hands-on-portals).
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -18,25 +18,25 @@ Nim made its first entry in TIOBE index in 2017 at position 129,
 last year it entered the top-100, and in the last 2 months the top-50 ([https://forum.nim-lang.org/t/8297](https://forum.nim-lang.org/t/8297)).
 We hope this release will reinforce this trend, building on Nim's core strengths:
 a practical, compiled systems programming language; offering C-like performance and portability;
-Python-like syntax; LISP-like flexibility; strong C, C++, JS, Python interop;
+Python-like syntax; Lisp-like flexibility; strong C, C++, JS, Python interop;
 and best-in class metaprogramming.
 
 Why use Nim?
-* one language to rule them all: write your iOS/android/web frontend and backend in the same language, from a [gameboy kickstarter](https://forum.nim-lang.org/t/8375) to a [blockchain client](https://github.com/status-im).
-* concise and readable like python: `echo "hello world"` is a 1-liner (5 lines in C, C++, go, java).
-* small binaries: `echo "hello world"` generates a 73K binary (go: 2MB, rust: 377K, C++: 56K), thanks to dead code elimination [1].
-* fast compile times: a full compiler rebuild takes ~12s (rust: 15mn, gcc: 30mn+, clang: 1hr+, go: 90s) [2].
+* one language to rule them all: write your iOS/Android/web frontend and backend in the same language, from a [Gameboy kickstarter](https://forum.nim-lang.org/t/8375) to a [blockchain client](https://github.com/status-im).
+* concise and readable like Python: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
+* small binaries: `echo "hello world"` generates a 73K binary (Go: 2MB, Rust: 377K, C++: 56K) [1].
+* fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
 * C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
-* target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), nintendo switch or [gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
-* 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, python (via [nimpy](https://github.com/yglukhov/nimpy))
-* built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands nim code and runnable examples that stay in sync
+* target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), Nintendo Switch or [Gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
+* 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, Python (via [nimpy](https://github.com/yglukhov/nimpy))
+* built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands Nim code and runnable examples that stay in sync
 
-Last but not least, `macros` let you manipulate/generate code at compile time instead of relying on code generators, allowing for example to easily write DSLs or extend the language, all in user code:
+Last but not least, macros let you manipulate/generate code at compile time instead of relying on code generators, allowing for example to easily write DSLs or extend the language, all in user code:
   - [karax](https://github.com/karaxnim/karax) for react+JSX-like Single Page Applications
   - [cligen](https://github.com/c-blake/cligen) for API-inferred command line generator
   - [std/wrapnils](https://nim-lang.github.io/Nim/wrapnils.html) JS-like optional chaining
-  - [std/strformat](https://nim-lang.github.io/Nim/strformat.html) python-like f-strings
+  - [std/strformat](https://nim-lang.github.io/Nim/strformat.html) Python-like f-strings
 
 This release includes improvements in the following areas:
 * new language features (`iterable[T]`, user-defined literals, private imports, strict effects, dot-like operators, block arguments with optional parameters)
@@ -713,7 +713,7 @@ Compatibility notes:
   for more details.
 - A type conversion from one `enum` type to another now produces an `[EnumConv]` warning.
   You should use `ord` (or `cast`, but the compiler won't help, if you misuse it) instead.
-  ```
+  ```nim
   type A = enum a1, a2
   type B = enum b1, b2
   echo a1.B # produces a warning
@@ -883,9 +883,9 @@ Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
 * [2] commands used:
   for nim: `nim c --forceBuild compiler/nim`
   for rust: `./x.py build`, see also https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/
-  for gcc: see https://unix.stackexchange.com/questions/421822/how-long-does-it-take-to-compile-gcc-7-3-0
+  for GCC: see https://unix.stackexchange.com/questions/421822/how-long-does-it-take-to-compile-gcc-7-3-0
   https://solarianprogrammer.com/2016/10/07/building-gcc-ubuntu-linux/
-  for clang: see https://quuxplusone.github.io/blog/2018/04/16/building-llvm-from-source/
+  for Clang: see https://quuxplusone.github.io/blog/2018/04/16/building-llvm-from-source/
   for go: `./make.bash`
 * [3] a separate nimscript file can be used if needed to execute code at compile time
       before compiling the main program but it's in the same language

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -16,22 +16,22 @@ Here are some stats:
 * 280 new nimble packages
 
 Nim made its first entry in TIOBE index in 2017 at position 129,
-last year it entered the top-100, and last 2 months it entered the top-50 (https://forum.nim-lang.org/t/8297).
+last year it entered the top-100, and in the last 2 months the top-50 (https://forum.nim-lang.org/t/8297).
 We hope this release will reinforce this trend, building on Nim's core strengths:
 a practical, compiled systems programming language; offering C-like performance and portability;
 Python-like syntax; LISP-like flexibility; strong C, C++, JS, Python interop;
 and best-in class metaprogramming.
 
 This release includes improvements in the following areas:
-* new language features (user defined literals, private imports, strict effects, `iterable[T]`, dot-like operators, block arguments with optional params)
+* new language features (user defined literals, private imports, strict effects, `iterable[T]`, dot-like operators, block arguments with optional parameters)
 * new compiler features (`nim --eval:cmd`, custom nimscript extensions, customizable compiler messages)
-* major improvements to `--gc:arc`, `--gc:orc`
+* major improvements to `--gc:arc` and `--gc:orc`
 * correctness and performance of integer and float parsing and rendering in all backends
 * significant improvements in error messages, showing useful context
 * doc generation logic and documentation, in particular `runnableExamples` now works in more contexts and replaces `code-block`.
 * made JS, VM and nimscript backend more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
 * support for Apple silicon/M1, 32-bit RISC-V, CROSSOS, improved support for NodeJS backend
-* major improvements to the following modules: `system, math, random, json, jsonutils, os, typetraits, wrapnils, lists, hashes` including performance improvements
+* major improvements to the following modules: `system`, `math`, `random`, `json`, `jsonutils`, `os`, `typetraits`, `wrapnils`, `lists`, `hashes` including performance improvements
 * deprecated a number of error prone or redundant mis-features
 
 
@@ -40,7 +40,7 @@ We recommend everyone to upgrade to 1.6:
 
 ## New users
 
-Check out if the package manager of your OS already ships version 1.6 or
+Check out if your package manager already ships version 1.6 or
 install it as described [here](https://nim-lang.org/install.html).
 
 
@@ -83,13 +83,13 @@ Nim is a community driven collaborative effort that welcomes all contributions, 
 # Backward compatibility and preview flags
 
 Starting with this release, we've introduced preview flags of the form `-d:nimPreviewX`
-(e.g. `-d:nimPreviewFloatRoundtrip`); they allow users to opt-in a new stdlib/compiler behavior
-that will likely become default in the next or a future release.
+(e.g. `-d:nimPreviewFloatRoundtrip`), which allow users to opt-in to new stdlib/compiler behavior
+that will likely become the default in the next or a future release.
 These staging flags are aimed at minimizing backward compatibility issues.
 
 We also introduced opt-out flags of the form `-d:nimLegacyX`,  e.g. `-d:nimLegacyCopyFile`,
-for cases where the default was changed to the new behavior,
-and an explicit opt-out is needed for some transition period.
+for cases where the default was changed to the new behavior.
+For a transition period, these flags can be used to get the old behaviour.
 
 # Major new features
 With so many new features, pinpointing the most salient ones is a subjective exercise,
@@ -98,7 +98,7 @@ but here are a select few:
 
 ## Strict effects
 The effect system was refined and there is a new `.effectsOf` annotation that does
-explicitly what was previously done implicitly. See [manual](https://nim-lang.github.io/Nim/manual.html#effect-system-effectsof-annotation) for details.
+explicitly what was previously done implicitly. See the [manual](https://nim-lang.github.io/Nim/manual.html#effect-system-effectsof-annotation) for more details.
 To write code that is portable with older Nim versions, use this idiom:
 
 ```nim
@@ -110,11 +110,11 @@ else:
 proc mysort(s: seq; cmp: proc(a, b: T): int) {.effectsOf: cmp.}
 ```
 
-To enable the new effect system, use --experimental:strictEffects. See [#18777](https://github.com/nim-lang/Nim/pull/18777) and RFC [#408](https://github.com/nim-lang/RFCs/issues/408).
+To enable the new effect system, compile with `--experimental:strictEffects`. See also [#18777](https://github.com/nim-lang/Nim/pull/18777) and RFC [#408](https://github.com/nim-lang/RFCs/issues/408).
 
 
 ## `iterable[T]`
-Added `iterable[T]` type class to match called iterators, which enables writing:
+The `iterable[T]` type class was added to match called iterators, which enables writing:
 ```nim
 template fn(a: iterable) # or template fn[T](a: iterable[T])
 # instead of:
@@ -182,7 +182,7 @@ echo a # with `-d:nimPreviewFloatRoundtrip`: 9.78, like in python3 (instead of  
 ```
 
 ## New `std/jsbigints` module
-Provides arbitrary precision integers for JS target. See PR [#16409](https://github.com/nim-lang/Nim/pull/16409).
+Provides arbitrary precision integers for the JS target. See PR [#16409](https://github.com/nim-lang/Nim/pull/16409).
 Example:
 ```nim
 import std/jsbigints
@@ -219,9 +219,9 @@ assert readFile(path) == "foo"
 
 
 ## User defined literals
-- Custom numeric literals (e.g. `-128'bignum`) are now supported.
-- The unary minus in `-1` is now part of the integer literal, it is now parsed as a single token.
-  This implies that edge cases like `-128'i8` finally work correctly.
+Custom numeric literals (e.g. `-128'bignum`) are now supported.
+Additionally, the unary minus in `-1` is now part of the integer literal, i.e. it is now parsed as a single token.
+This implies that edge cases like `-128'i8` finally work correctly.
 Example:
 ```nim
 func `'big`*(num: cstring): JsBigInt {.importjs: "BigInt(#)".}
@@ -245,8 +245,8 @@ assert j.?a1.?a2.getInt == 10
 ```
 
 
-## Block arguments now support optional params
-This solves a major pain point for routines accepting block params, see PR #18631 for details:
+## Block arguments now support optional parameters
+This solves a major pain point for routines accepting block parameters, see PR #18631 for details:
 ```nim
 template fn(a = 1, b = 2, body) = discard
 fn(1, 2): # already works
@@ -254,7 +254,7 @@ fn(1, 2): # already works
 fn(a = 1): # now works
   bar
 ```
-ditto with multiple block args via do:
+ditto with multiple block arguments via `do`:
 ```nim
 template fn(a = 1, b = 2, body1, body2) = discard
 fn(a = 1): # now works
@@ -318,7 +318,7 @@ The following modules were added (they are discussed in the rest of the text):
 Compatibility notes:
 - `system.delete` had a most surprising behavior when the index passed to it was out of
   bounds (it would delete the last entry then). Compile with `-d:nimStrictDelete` so
-  that an index error is produced instead. But be aware that your code might depend on
+  that an index error is produced instead. Be aware however that your code might depend on
   this quirky behavior so a review process is required on your part before you can
   use `-d:nimStrictDelete`. To make this review easier, use the `-d:nimAuditDelete`
   switch, it pretends that `system.delete` is deprecated so that it is easier to see
@@ -327,8 +327,8 @@ Compatibility notes:
   `-d:nimStrictDelete` will become the default in upcoming versions.
 - `cuchar` is now deprecated as it aliased `char` where arguably it should have aliased `uint8`.
   Please use `char` or `uint8` instead.
-- `repr` now doesn't insert trailing newline; previous behavior was very inconsistent,
-  see [#16034](https://github.com/nim-lang/Nim/pull/16034). Use `-d:nimLegacyReprWithNewline` for previous behavior. `repr` now also
+- `repr` now doesn't insert trailing newlines; the previous behavior was very inconsistent,
+  see [#16034](https://github.com/nim-lang/Nim/pull/16034). Use `-d:nimLegacyReprWithNewline` for the previous behavior. `repr` now also
   renders ASTs correctly for user defined literals, setters, `do`, etc.
 - Deprecated `any`. See RFC [#281](https://github.com/nim-lang/RFCs/issues/281).
 - The unary slice `..b` was deprecated, use `0..b` instead.
@@ -345,8 +345,8 @@ Compatibility notes:
 - Added `frexp` overload procs. Deprecated `c_frexp`, use `frexp` instead.
 
 Compatibility notes:
-- `math.round` now is rounded "away from zero" in JS backend which is consistent
-  with other backends. See [#9125](https://github.com/nim-lang/Nim/pull/9125). Use `-d:nimLegacyJsRound` for previous behavior.
+- `math.round` now rounds "away from zero" in the JS backend, which is consistent
+  with other backends. See [#9125](https://github.com/nim-lang/Nim/pull/9125). Use `-d:nimLegacyJsRound` for the previous behavior.
 
 
 ## Random number generators: `std/random`, `std/sysrand`, `std/oids`
@@ -354,7 +354,7 @@ Compatibility notes:
   Useful for library authors.
 - Added `initRand()` overload with no argument which uses the current time as a seed.
 - `initRand(seed)` now allows `seed == 0`.
-- Added `std/sysrand` module to get random numbers from a secure source
+- Added `std/sysrand` module to get random numbers from a secure source.
 - Fixed overflow bugs.
 - Fix `initRand` to avoid random number sequences overlapping, refs [#18744](https://github.com/nim-lang/Nim/pull/18744).
 - `std/oids` now uses `std/random`.
@@ -405,7 +405,7 @@ Compatibility notes:
 - Fixed buffer overflow bugs in `std/net`.
 - Exported `sslHandle` from `std/net` and `std/asyncnet`.
 - Added `hasDataBuffered` to `std/asyncnet`.
-- various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover `request` function's
+- Various functions in `std/httpclient` now accept `url` of type `Uri`. Moreover `request` function's
   `httpMethod` argument of type `string` was deprecated in favor of `HttpMethod` `enum` type; see [#15919](https://github.com/nim-lang/Nim/pull/15919).
 - Added `asyncdispatch.activeDescriptors` that returns the number of currently
   active async event handles/file descriptors.
@@ -416,17 +416,16 @@ Compatibility notes:
 - Added `htmlgen.portal` for [making "SPA style" pages using HTML only](https://web.dev/hands-on-portals).
 
 Compatibility notes:
-- On Windows the SSL library now checks for valid certificates.
+- On Windows, the SSL library now checks for valid certificates.
   It uses the `cacert.pem` file for this purpose which was extracted
   from `https://curl.se/ca/cacert.pem`. Besides
-  the OpenSSL DLLs (e.g. libssl-1_1-x64.dll, libcrypto-1_1-x64.dll) you
+  the OpenSSL DLLs (e.g. `libssl-1_1-x64.dll`, `libcrypto-1_1-x64.dll`) you
   now also need to ship `cacert.pem` with your `.exe` file.
 
 
 ## `std/hashes`
 - `hashes.hash` can now support `object` and `ref` (can be overloaded in user code),
   if `-d:nimEnableHashRef` is used.
-
 - `hashes.hash(proc|ptr|ref|pointer)` now calls `hash(int)` and honors `-d:nimIntHash1`,
   `hashes.hash(closure)` has also been improved.
 
@@ -449,7 +448,7 @@ Compatibility notes:
   (instead of skipping them sometimes as it was before).
 - Added optional `followSymlinks` argument to `setFilePermissions`.
 - Added a simpler to use `io.readChars` overload.
-- Added `socketstream` module that wraps sockets in the stream interface
+- Added `socketstream` module that wraps sockets in the stream interface.
 - Added experimental `linenoise.readLineStatus` to get line and status (e.g. ctrl-D or ctrl-C).
 
 
@@ -461,7 +460,7 @@ Compatibility notes:
 - NodeJS backend now supports osenv: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
 
 Compatibility notes:
-- `std/os`: `putEnv` now raises if the 1st argument contains a `=`
+- `std/os`: `putEnv` now raises if the 1st argument contains a `=`.
 
 
 ## POSIX
@@ -475,7 +474,7 @@ Compatibility notes:
   for previous behavior.
 - Added `posix_utils.osReleaseFile` to get system identification from `os-release` file on Linux and the BSDs.
   https://www.freedesktop.org/software/systemd/man/os-release.html
-- Remove undefined behavior for `posix.open`
+- Remove undefined behavior for `posix.open`.
 
 
 ## `std/prelude`
@@ -486,19 +485,19 @@ Compatibility notes:
 
 
 ## String manipulation: `std/strformat`, `std/strbasics`
-- added support for parenthesized expressions.
-- added support for const string's instead of just string literals
+- Added support for parenthesized expressions.
+- Added support for const string's instead of just string literals
 
 - Added `std/strbasics` for high performance string operations.
-  Added `strip`, `setSlice`, `add(a: var string, b: openArray[char])`.
+- Added `strip`, `setSlice`, `add(a: var string, b: openArray[char])`.
 
 
 ## `std/wrapnils`
 - `std/wrapnils` doesn't use `experimental:dotOperators` anymore, avoiding
   issues like bug [#13063](https://github.com/nim-lang/Nim/issues/13063) (which affected error messages)
   for modules importing `std/wrapnils`.
-  Added `??.` macro which returns an `Option`.
-  `std/wrapnils` can now be used to protect against `FieldDefect` errors in
+- Added `??.` macro which returns an `Option`.
+- `std/wrapnils` can now be used to protect against `FieldDefect` errors in
   case objects, generates optimal code (no overhead compared to manual
   if-else branches), and preserves lvalue semantics which allows modifying
   an expression.
@@ -516,7 +515,7 @@ Compatibility notes:
   its argument, `addMoved`, is also supplied. 
   See PR [#16362](https://github.com/nim-lang/Nim/pull/16362), [#16536](https://github.com/nim-lang/Nim/pull/16536).
 
-- new module: `std/packedsets`
+- New module: `std/packedsets`
   Generalizes `std/intsets`, see PR [#15564](https://github.com/nim-lang/Nim/pull/15564).
 
 Compatibility notes:
@@ -536,7 +535,7 @@ Compatibility notes:
 ## `std/macros` and AST
 - New module `std/genasts` containing `genAst` that avoids the problems inherent with `quote do` and can
   be used as a replacement.
-  use `-d:nimLegacyMacrosCollapseSymChoice` to get previous behavior.
+  Use `-d:nimLegacyMacrosCollapseSymChoice` to get the previous behavior.
 
 - The required name of case statement macros for the experimental
   `caseStmtMacros` feature has changed from `match` to `` `case` ``.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -359,7 +359,7 @@ The following modules were added (they are discussed in the rest of the text):
 - `addInt` now supports unsigned integers.
 
 Compatibility notes:
-- `system.delete` had a most surprising behavior when the index passed to it was out of
+- `system.delete` had surprising behavior when the index passed to it was out of
   bounds (it would delete the last entry then). Compile with `-d:nimStrictDelete` so
   that an index error is produced instead. Be aware however that your code might depend on
   this quirky behavior so a review process is required on your part before you can

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -186,8 +186,10 @@ Provides arbitrary precision integers for the JS target. See PR [#16409](https:/
 Example:
 ```nim
 import std/jsbigints
-assert big"2" ** big"64" == big"18446744073709551616"
+assert 2'big ** 65'big == 36893488147419103232'big
+echo 2'big ** 65'big # 36893488147419103232n
 ```
+
 
 ## New `std/sysrand` module
 Cryptographically secure pseudorandom number generator, see PR [#16459](https://github.com/nim-lang/Nim/pull/16459).

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -23,7 +23,7 @@ Python-like syntax; LISP-like flexibility; strong C, C++, JS, python interop;
 and best-in class metaprogramming.
 
 This release includes improvements in the following areas:
-* new language features (user defined literals, private imports, strict effects, `iterable[T]`, new style concepts, dot-like operators, block arguments with optional params)
+* new language features (user defined literals, private imports, strict effects, `iterable[T]`, dot-like operators, block arguments with optional params)
 * new compiler features (`nim --eval:cmd`, custom nimscript extensions, customizable compiler messages)
 * major improvements to `--gc:arc`, `--gc:orc`
 * correctness and performance of integer and float parsing and rendering in all backends
@@ -206,15 +206,6 @@ Example:
 func `'big`*(num: cstring): JsBigInt {.importjs: "BigInt(#)".}
 assert 0xffffffffffffffff'big == (1'big shl 64'big) - 1'big
 ```
-
-## New-style concepts
-Example:
-```nim
-type
-  Comparable = concept # no T, an atom
-    proc cmp(a, b: Self): int
-```
-See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
 
 
 ## Dot-like operators
@@ -664,6 +655,16 @@ Compatibility notes:
 
 - Reusing a type name in a different scope now works, refs [#17710](https://github.com/nim-lang/Nim/pull/17710).
 - Fixed implicit and explicit generics in procedures, refs [#18808](https://github.com/nim-lang/Nim/pull/18808).
+
+
+## New-style concepts
+Example:
+```nim
+type
+  Comparable = concept # no T, an atom
+    proc cmp(a, b: Self): int
+```
+See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
 
 
 ## Lexical / syntactic

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -205,7 +205,7 @@ assert 0xffffffffffffffff'big == (1'big shl 64'big) - 1'big
 ```
 
 ## New-style concepts
-E.g.:
+Example:
 ```nim
 type
   Comparable = concept # no T, an atom
@@ -734,7 +734,7 @@ Compatibility notes:
 - TLS: OSX now uses native TLS (`--tlsEmulation:off`), TLS now works with importcpp non-POD types,
   such types must use `.cppNonPod` and `--tlsEmulation:off`should be used.
 - Added `unsafeIsolate` and `extract` to `std/isolation`.
-- Added new module: `std/tasks`
+- Added `std/tasks`, a new module containing primitives for creating parallel programs.
 
 
 ## Memory management
@@ -748,7 +748,8 @@ Compatibility notes:
   This is only supported for `--gc:orc` or `--gc:arc`.
 
 Compatibility notes:
-- `--newruntime` and `--refchecks` are deprecated.
+- `--newruntime` and `--refchecks` are deprecated,
+  use `--gc:arc`, --gc:orc`, or `--gc:none` as appropriate instead.
 
 
 ## Docgen
@@ -803,7 +804,7 @@ func fn*(a: int): int = 42  ## Doc comment
 - `testament`: added `nimoutFull: bool` spec to compare full output of compiler
   instead of a subset; many bugfixes to testament.
 
-- Added `atlas` helper tool.
+- Added `atlas` a tool for automating workflows involing "cloning" a nimble package and dependencies recursively
 
 ## Misc/cleanups
 - Deprecated `TaintedString` and `--taintmode`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -25,7 +25,8 @@ Why use Nim?
 * one language to rule them all: write your iOS/android/web frontend and backend in the same language, from a [gameboy kickstarter](https://forum.nim-lang.org/t/8375) to a [blockchain client](https://github.com/status-im).
 * concise and readable like python: `echo "hello world"` is a 1-liner (5 lines in C, C++, go, java).
 * small binaries: `echo "hello world"` generates a 73K binary (go: 2MB, rust: 377K, C++: 56K), thanks to dead code elimination [1].
-* good compile times: a full compiler rebuild takes ~12s (rust: 15mn, gcc: 30mn+, clang: 1hr+, go: 90s) [2].
+* fast compile times: a full compiler rebuild takes ~12s (rust: 15mn, gcc: 30mn+, clang: 1hr+, go: 90s) [2].
+* C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
 * target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), nintendo switch or [gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
 * 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, python (via [nimpy](https://github.com/yglukhov/nimpy))

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -83,6 +83,7 @@ Starting with this release, we've introduced preview flags of the form `-d:nimPr
 (e.g. `-d:nimPreviewFloatRoundtrip`); they allow users to opt-in a new stdlib/compiler behavior
 that will likely become default in the next or a future release.
 These staging flags are aimed at minimizing backward compatibility issues.
+
 We also introduced opt-out flags of the form `-d:nimLegacyX`,  e.g. `-d:nimLegacyCopyFile`,
 for cases where the default was changed to the new behavior,
 and an explicit opt-out is needed for some transition period.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -27,7 +27,7 @@ Why use Nim?
 * small binaries: `echo "hello world"` generates a 73K binary (go: 2MB, rust: 377K, C++: 56K), thanks to dead code elimination [1].
 * good compile times: a full compiler rebuild takes ~12s (rust: 15mn, gcc: 30mn+, clang: 1hr+, go: 90s) [2].
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
-* target any platform where there's a C compiler [4], from embedded devices to WASM to nintendo or gameboy
+* target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), nintendo switch or [gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
 * 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, python (via [nimpy](https://github.com/yglukhov/nimpy))
 * built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands nim code and runnable examples that stay in sync
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -42,8 +42,8 @@ If you have installed a previous version of Nim using `choosenim`,
 getting Nim 1.6 is as easy as:
 
 ```bash
-$ choosenim update self
-$ choosenim update stable
+choosenim update self
+choosenim update stable
 ```
 
 If you don't have `choosenim`, you can follow the same
@@ -51,9 +51,9 @@ If you don't have `choosenim`, you can follow the same
 
 ## Building from source
 ```bash
-$ git clone https://github.com/nim-lang/Nim
-$ cd Nim
-$ sh build_all.sh
+git clone https://github.com/nim-lang/Nim
+cd Nim
+sh build_all.sh
 ```
 The last command can be re-run after pulling new commits.
 Note that the `csources` repo used was changed to `csources_v1`, the new setup is designed to be forward and backward compatible.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -26,7 +26,7 @@ Why use Nim?
 * concise and readable like python: `echo "hello world"` is a 1-liner (5 lines in C, C++, go, java).
 * small binaries: `echo "hello world"` generates a 73K binary (go: 2MB, rust: 377K, C++: 56K), thanks to dead code elimination [1].
 * fast compile times: a full compiler rebuild takes ~12s (rust: 15mn, gcc: 30mn+, clang: 1hr+, go: 90s) [2].
-* C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html)
+* C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
 * target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), nintendo switch or [gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
 * 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, python (via [nimpy](https://github.com/yglukhov/nimpy))

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -28,7 +28,7 @@ Why use Nim?
 * fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
 * C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
-* target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), Nintendo Switch or [Gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
+* target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), Nintendo Switch or [Game Boy Advance](https://forum.nim-lang.org/t/8375)
 * zero-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, Python (via [nimpy](https://github.com/yglukhov/nimpy))
 * built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands Nim code and runnable examples that stay in sync
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -91,6 +91,20 @@ We also introduced opt-out flags of the form `-d:nimLegacyX`,  e.g. `-d:nimLegac
 for cases where the default was changed to the new behavior.
 For a transition period, these flags can be used to get the old behaviour.
 
+Here's the list of these flags introduced in this release, refer to the text below for explanations:
+- `-d:nimLegacyCopyFile`
+- `-d:nimLegacyJsRound`
+- `-d:nimLegacyJsonutilsHoleyEnum`
+- `-d:nimLegacyMacrosCollapseSymChoice`
+- `-d:nimLegacyParseQueryStrict`
+- `-d:nimLegacyRandomInitRand`
+- `-d:nimLegacyReprWithNewline`
+- `-d:nimLegacySigpipeHandler`
+- `-d:nimLegacyTypeMismatch`
+- `-d:nimPreviewDotLikeOps`
+- `-d:nimPreviewFloatRoundtrip`
+
+
 # Major new features
 With so many new features, pinpointing the most salient ones is a subjective exercise,
 but here are a select few:

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -657,7 +657,7 @@ Compatibility notes:
 - `std/cstrutils` now works in VM.
 
 
-## OS-specific notes
+## OS/platform-specific notes
 - Support for Apple silicon/M1.
 - Support for 32-bit RISC-V, refs [#16231](https://github.com/nim-lang/Nim/pull/16231).
 - Support for armv8l, refs [#18901](https://github.com/nim-lang/Nim/pull/18901).

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -22,13 +22,15 @@ Python-like syntax; Lisp-like flexibility; strong C, C++, JS, Python interop;
 and best-in-class metaprogramming.
 
 Why use Nim?
-* one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum), [scientific computing](https://github.com/SciNim), [machine learning](https://github.com/mratsim/Arraymancer), [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico), [embedded](https://github.com/EmbeddedNim).
+* one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum), [scientific computing](https://github.com/SciNim), [deep learning](https://github.com/mratsim/Arraymancer), [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico), [embedded](https://github.com/EmbeddedNim).
 * concise and readable like Python: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
 * small binaries: `echo "hello world"` generates a 73K binary (or 5K with further options) (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
 * C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
-* target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), Nintendo Switch or [Game Boy Advance](https://forum.nim-lang.org/t/8375)
+* target any platform with a C compiler: [Android and iOS](https://github.com/pragmagic/godot-nim#made-with-godot-nim),
+  [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731),
+  [WASM](https://forum.nim-lang.org/t/4779), Nintendo Switch, [Game Boy Advance](https://forum.nim-lang.org/t/8375).
 * zero-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, Python (via [nimpy](https://github.com/yglukhov/nimpy))
 * built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands Nim code and runnable examples that stay in sync
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -568,8 +568,8 @@ Compatibility notes:
 - Empty environment variable values are now supported across OS's and backends.
 - Environment variable APIs now work in multithreaded scenarios, by delegating to direct OS calls
   instead of trying to keep track of the environment.
-- NodeJS backend now supports `osenv`: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
-- `osenv` now works in all backends (c,cpp,vm,nims,js with -d:nodejs), see PR [#18615](https://github.com/nim-lang/Nim/pull/18615).
+- `putEnv`, `delEnv` now work at compile time.
+- NodeJS backend now supports osenv: `getEnv`, `putEnv`, `envPairs`, `delEnv`, `existsEnv`.
 
 Compatibility notes:
 - `std/os`: `putEnv` now raises if the first argument contains a `=`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -148,6 +148,8 @@ block:
   echo t.monthdayZero # ok
 ```
 
+See PR [#17706](https://github.com/nim-lang/Nim/pull/17706) for additional details.
+
 
 ## `nim --eval:cmd`
 Added `nim --eval:cmd` to evaluate a command directly:, e.g.: `nim --eval:"echo 1"`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -29,7 +29,7 @@ Why use Nim?
 * C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
 * target any platform with a C compiler: [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731), [WASM](https://forum.nim-lang.org/t/4779), Nintendo Switch or [Gameboy](https://www.kickstarter.com/projects/penguinrik/goodboy-galaxy-exploration-platform-game-gba-pc-and-switch)
-* 0-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, Python (via [nimpy](https://github.com/yglukhov/nimpy))
+* zero-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, Python (via [nimpy](https://github.com/yglukhov/nimpy))
 * built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands Nim code and runnable examples that stay in sync
 
 Last but not least, macros let you manipulate/generate code at compile time instead of relying on code generators, allowing for example to easily write DSLs or extend the language, all in user code:

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -67,7 +67,10 @@ The last command can be re-run after pulling new commits.
 Note that the `csources` repo used was changed to `csources_v1`, the new setup is designed to be forward and backward compatible.
 
 ## Building from a CI setup
-We now have an API to be used in CI which abstracts the implementation details: `. ci/funs.sh && nimBuildCsourcesIfNeeded`; in fact all the existing CI pipelines have been refactored to use this, see
+We now have bash APIs to (re-)build Nim from source which hide implementation details, for example:
+`. ci/funs.sh && nimBuildCsourcesIfNeeded`.
+This can be useful for CI when alternatives (using nightly builds or a Docker image) are not suitable;
+in fact all the existing CI pipelines have been refactored to use this, see
 [#17815](https://github.com/nim-lang/Nim/pull/17815).
 
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -187,7 +187,7 @@ Example:
 ```nim
 import std/jsbigints
 assert 2'big ** 65'big == 36893488147419103232'big
-echo 0xdeadbeaf'big shl 4'big # 59774855920n
+echo 0xdeadbeef'big shl 4'big # 59774856944n
 ```
 
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -94,8 +94,8 @@ but here are a select few:
 
 ## Strict effects
 The effect system was refined and there is a new `.effectsOf` annotation that does
-  explicitly what was previously done implicitly. See the manual for details.
-  To write code that is portable with older Nim versions, use this idiom:
+explicitly what was previously done implicitly. See [manual](https://nim-lang.github.io/Nim/manual.html#effect-system-effectsof-annotation) for details.
+To write code that is portable with older Nim versions, use this idiom:
 
 ```nim
 when defined(nimHasEffectsOf):

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -774,7 +774,7 @@ and RFC [#168](https://github.com/nim-lang/RFCs/issues/168) for details.
 - `typedesc[Foo]` now renders as such instead of `type Foo` in compiler messages.
 - `runnableExamples` now show originating location in stacktraces on failure.
 - `SuccessX` message now shows more useful information.
-- New `DuplicateModuleImport` warning, improved `UnusedImport` and `XDeclaredButNotUsed` accuracy.
+- New `DuplicateModuleImport` warning; improved `UnusedImport` and `XDeclaredButNotUsed` accuracy.
 
 Compatibility notes:
 - `--hint:CC` now prints to stderr (like all other hints) instead of stdout.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -253,6 +253,21 @@ echo 0xdeadbeef'big shl 4'big # 59774856944n
 ```
 
 
+## New `std/jsfetch` module
+Provides a wrapper for JS Fetch API.
+Example:
+```nim
+# requires -d:nimExperimentalAsyncjsThen
+import std/[jsfetch, asyncjs, jsconsole, jsffi, sugar]
+proc fn {.async.} =
+  await fetch("https://api.github.com/users/torvalds".cstring)
+    .then((response: Response) => response.json())
+    .then((json: JsObject) => console.log(json))
+    .catch((err: Error) => console.log("Request Failed", err))
+discard fn()
+```
+
+
 ## New `std/sysrand` module
 Cryptographically secure pseudorandom number generator,
 allows generating random numbers from a secure source provided by the operating system.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -290,7 +290,7 @@ The following modules were added (they are discussed in the rest of the text):
 
 
 ## `system`
-- Added `system.prepareStrMutation` for better support of low
+- Added `system.prepareMutation` for better support of low
   level `moveMem`, `copyMem` operations for `gc:orc`'s copy-on-write string
   implementation.
 - `system.addEscapedChar` now renders `\r` as `\r` instead of `\c`, to be compatible

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -877,7 +877,7 @@ func fn*(a: int): int = 42  ## Doc comment
 
 
 # Footnotes
-Evaluated on a 8-core 2019 mac 11.5, 2.3GHz with 64GB RAM.
+Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
 * [1] command used: `nim c -o:/tmp/main -d:danger --eval:'echo "hello world"'`
 * [2] commands used:
   for nim: `nim c --forceBuild compiler/nim`

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -26,10 +26,10 @@ Why use Nim?
   [scientific computing](https://github.com/SciNim), [deep learning](https://github.com/mratsim/Arraymancer),
   [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico),
   [embedded](https://github.com/EmbeddedNim), see also some [companies using nim](https://github.com/nim-lang/Nim/wiki/Organizations-using-Nim).
-* concise and readable like Python: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
+* concise and readable: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
 * small binaries: `echo "hello world"` generates a 73K binary (or 5K with further options) (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
-* C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
+* native performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
 * target any platform with a C compiler: [Android and iOS](https://github.com/pragmagic/godot-nim#made-with-godot-nim),
   [embedded systems](https://github.com/elcritch/nesper), [micro-controllers](https://forum.nim-lang.org/t/7731),
@@ -37,11 +37,9 @@ Why use Nim?
 * zero-overhead interop lets you reuse code in C, C++ (including templates, [C++ STL](https://clonkk.github.io/nim-cppstl/cppstl.html)), JS, Objective-C, Python (via [nimpy](https://github.com/yglukhov/nimpy))
 * built-in [documentation generator](https://nim-lang.github.io/Nim/system.html) that understands Nim code and runnable examples that stay in sync
 
-Last but not least, macros let you manipulate/generate code at compile time instead of relying on code generators, allowing for example to easily write DSLs or extend the language, all in user code:
-  - [karax](https://github.com/karaxnim/karax) for react+JSX-like Single Page Applications
-  - [cligen](https://github.com/c-blake/cligen) for API-inferred command line generator
-  - [std/wrapnils](https://nim-lang.github.io/Nim/wrapnils.html) JS-like optional chaining
-  - [std/strformat](https://nim-lang.github.io/Nim/strformat.html) Python-like f-strings
+Last but not least, macros let you manipulate/generate code at compile time instead of relying on code generators,
+enabling writing DSLs and language extensions in user code. Typical examples include implementing
+Python f-strings, optional chaining, command line generators, react-like Single Page Apps, protobuf serialization and binding generators [4].
 
 This release includes improvements in the following areas:
 * new language features (`iterable[T]`, user-defined literals, private imports, strict effects, dot-like operators, block arguments with optional parameters)
@@ -948,3 +946,9 @@ Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
   for Go: `./make.bash`
 * [3] a separate nimscript file can be used if needed to execute code at compile time
       before compiling the main program but it's in the same language
+* [4] Here are some example applications of macros:
+  - [karax](https://github.com/karaxnim/karax) for react+JSX-like Single Page Applications
+  - [cligen](https://github.com/c-blake/cligen) for API-inferred command line generator
+  - [std/wrapnils](https://nim-lang.github.io/Nim/wrapnils.html) JS-like optional chaining
+  - [std/strformat](https://nim-lang.github.io/Nim/strformat.html) Python-like f-strings
+  - [protobuf-nim](https://github.com/PMunch/protobuf-nim) pure Nim implementation of protocol buffers.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -187,7 +187,7 @@ Example:
 ```nim
 import std/jsbigints
 assert 2'big ** 65'big == 36893488147419103232'big
-echo 2'big ** 65'big # 36893488147419103232n
+echo 0xdeadbeaf'big shl 4'big # 59774855920n
 ```
 
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -160,10 +160,14 @@ It defaults to `e` (nimscript) but can also work with other commands, e.g.:
 ```bash
 find . | nim r --eval:'import strutils; for a in stdin.lines: echo a.toUpper'
 ```
-You can now use nim as a calculator, e.g. `nim --eval:'echo 3.1 / (1.2+7)'`.
-You can also use it to explore a module's APIs, including private symbols:
+
 ```bash
+# use as a calculator:
+nim --eval:'echo 3.1 / (1.2+7)'
+# explore a module's APIs, including private symbols:
 nim --eval:'import os {.all.}; echo weirdTarget'
+# use a custom backend:
+nim r -b:js --eval:"import std/jsbigints; echo 2'big ** 64'big"
 ```
 See PR [#15687](https://github.com/nim-lang/Nim/pull/15687) for more details.
 

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -808,7 +808,6 @@ func fn*(a: int): int = 42  ## Doc comment
 - `testament`: added `nimoutFull: bool` spec to compare full output of compiler
   instead of a subset; many bugfixes to testament.
 
-- Added `atlas` a tool for automating workflows involving "cloning" a nimble package and dependencies recursively
 
 ## Misc/cleanups
 - Deprecated `TaintedString` and `--taintmode`.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -352,7 +352,6 @@ Compatibility notes:
   use `-d:nimStrictDelete`. To make this review easier, use the `-d:nimAuditDelete`
   switch, it pretends that `system.delete` is deprecated so that it is easier to see
   where it was used in your code.
-
   `-d:nimStrictDelete` will become the default in upcoming versions.
 - `cuchar` is now deprecated as it aliased `char` where arguably it should have aliased `uint8`.
   Please use `char` or `uint8` instead.
@@ -681,7 +680,6 @@ Compatibility notes:
   via `{.experimental: "overloadableEnums".}`. We hope that this feature allows for the
   development of more fluent (less ugly) APIs. See RFC [#373](https://github.com/nim-lang/RFCs/issues/373).
   for more details.
-
 - A type conversion from one `enum` type to another now produces an `[EnumConv]` warning.
   You should use `ord` (or `cast`, but the compiler won't help, if you misuse it) instead.
   ```
@@ -690,16 +688,12 @@ Compatibility notes:
   echo a1.B # produces a warning
   echo a1.ord.B # produces no warning
   ```
-
 - A dangerous implicit conversion to `cstring` now triggers a `[CStringConv]` warning.
   This warning will become an error in future versions! Use an explicit conversion
   like `cstring(x)` in order to silence the warning.
-
 - There is a new warning for *any* type conversion to `enum` that can be enabled via
   `.warning[AnyEnumConv]:on` or `--warning:AnyEnumConv:on`.
-
 - Reusing a type name in a different scope now works, refs [#17710](https://github.com/nim-lang/Nim/pull/17710).
-
 - Fixed implicit and explicit generics in procedures, refs [#18808](https://github.com/nim-lang/Nim/pull/18808).
 
 
@@ -720,7 +714,6 @@ See PR [#15251](https://github.com/nim-lang/Nim/pull/15251) for details.
   to parser limitations you **cannot** enable this feature via a
   pragma `{.experimental: "unicodeOperators".}` reliably, you need to enable
   it via the command line or in a configuration file.
-
 - `var a {.foo.} = expr` now works inside templates (except when `foo` is overloaded).
 
 
@@ -757,7 +750,6 @@ Compatibility notes:
 - JSON build instructions are now generated in `$nimcache/outFileBasename.json`
   instead of `$nimcache/projectName.json`. This allows avoiding recompiling a given project
   compiled with different options if the output file differs.
-
 - `--usenimcache` (implied by `nim r main`) now generates an output file that includes a hash of
   some of the compilation options, which allows caching generated binaries:
 ```bash
@@ -766,13 +758,10 @@ Compatibility notes:
   nim r main # uses cached binary
   nim r main arg1 arg2 # likewise (runtime arguments are irrelevant)
 ```
-
 - `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using Wine,
   e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`.
-
 - `nim` can compile version 1.4.0 as follows: `nim c --lib:lib --stylecheck:off -d:nimVersion140 compiler/nim`.
   `-d:nimVersion140` is not needed for bootstrapping, only for building 1.4.0 from devel.
-
 - `nim e` now accepts arbitrary file extensions for the nimscript file,
   although `.nims` is still the preferred extension in general.
 - The configuration subsystem now allows for `-d:release` and `-d:danger` to work as expected.
@@ -831,13 +820,14 @@ func fn*(a: int): int = 42  ## Doc comment
 - docgen now shows correct, canonical import paths in docs.
 - docgen now shows all routines in sidebar, and the proc signature is now shown in sidebar.
 
+
 ## Effects and checks
 - Significant improvement to error messages involving effect mismatches
-
 - There is a new `cast` section `{.cast(uncheckedAssign).}: body` that disables some
   compiler checks regarding `case objects`. This allows serialization libraries
   to avoid ugly, non-portable solutions. See RFC [#407](https://github.com/nim-lang/RFCs/issues/407).
   for more details.
+
 
 ## Tools
 - Major improvements to `nimgrep`, see PR [#15612

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -12,7 +12,12 @@ This is by far the biggest release yet, here are some stats:
 * documentation and minor improvements to 170 modules, including 312 new runnable examples
 * 280 new nimble packages
 
-Nim made its first entry in TIOBE index in 2017 at position 129, last year it entered the top-100, and last 2 months it entered the top-50 (https://forum.nim-lang.org/t/8297). We hope this release will reinforce this trend, building on Nim's core strenghs: a practical, compiled systems programming language offering C-like performance and portability, python-like syntax, LISP-like flexibility, strong C, C++, JS, python interop and best-in class metaprogramming.
+Nim made its first entry in TIOBE index in 2017 at position 129,
+last year it entered the top-100, and last 2 months it entered the top-50 (https://forum.nim-lang.org/t/8297).
+We hope this release will reinforce this trend, building on Nim's core strenghs:
+a practical, compiled systems programming language; offering C-like performance and portability;
+Python-like syntax; LISP-like flexibility; strong C, C++, JS, python interop;
+and best-in class metaprogramming.
 
 This release includes improvements in the following areas:
 * new language features (user defined literals, private imports, strict effects, `iterable[T]`, new style concepts, dot-like operators, block arguments with optional params)
@@ -169,7 +174,7 @@ assert urandom(1234) != urandom(1234) # unlikely to fail in practice
 
 
 ## New module: `std/tempfiles`
-Allows creating temporary files and directories, see PR #17361 and followups.
+Allows creating temporary files and directories, see PR [#17361](https://github.com/nim-lang/Nim/pull/17361) and followups.
 ```nim
 import std/tempfiles
 let tmpPath = genTempPath("prefix", "suffix.log", "/tmp/")

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -253,21 +253,6 @@ echo 0xdeadbeef'big shl 4'big # 59774856944n
 ```
 
 
-## New `std/jsfetch` module
-Provides a wrapper for JS Fetch API.
-Example:
-```nim
-# requires -d:nimExperimentalAsyncjsThen
-import std/[jsfetch, asyncjs, jsconsole, jsffi, sugar]
-proc fn {.async.} =
-  await fetch("https://api.github.com/users/torvalds".cstring)
-    .then((response: Response) => response.json())
-    .then((json: JsObject) => console.log(json))
-    .catch((err: Error) => console.log("Request Failed", err))
-discard fn()
-```
-
-
 ## New `std/sysrand` module
 Cryptographically secure pseudorandom number generator,
 allows generating random numbers from a secure source provided by the operating system.
@@ -368,6 +353,37 @@ The following modules were added (they are discussed in the rest of the text):
 - Deprecated `std/mersenne`.
 - Removed deprecated `std/iup` module from stdlib; it has already moved to
   [nimble](https://github.com/nim-lang/iup).
+
+
+## New `std/jsfetch` module
+Provides a wrapper for JS Fetch API.
+Example:
+```nim
+# requires -d:nimExperimentalAsyncjsThen
+import std/[jsfetch, asyncjs, jsconsole, jsffi, sugar]
+proc fn {.async.} =
+  await fetch("https://api.github.com/users/torvalds".cstring)
+    .then((response: Response) => response.json())
+    .then((json: JsObject) => console.log(json))
+    .catch((err: Error) => console.log("Request Failed", err))
+discard fn()
+```
+
+
+## New `std/tasks` module
+Provides basic primitives for creating parallel programs.
+Example:
+```nim
+import std/tasks
+var num = 0
+proc hello(a: int) = num+=a
+
+let b = toTask hello(13) # arguments must be isolated, see `std/isolation`
+b.invoke()
+assert num == 13
+b.invoke() # can be called again
+assert num == 26
+```
 
 
 ## New module: `std/setutils`
@@ -827,7 +843,7 @@ Compatibility notes:
 - TLS: macOS now uses native TLS (`--tlsEmulation:off`). TLS now works with `importcpp` non-POD types;
   such types must use `.cppNonPod` and `--tlsEmulation:off`should be used.
 - Added `unsafeIsolate` and `extract` to `std/isolation`.
-- Added `std/tasks`, a new module containing primitives for creating parallel programs.
+- Added `std/tasks`, see description above.
 
 
 ## Memory management

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -22,7 +22,10 @@ Python-like syntax; Lisp-like flexibility; strong C, C++, JS, Python interop;
 and best-in-class metaprogramming.
 
 Why use Nim?
-* one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum), [scientific computing](https://github.com/SciNim), [deep learning](https://github.com/mratsim/Arraymancer), [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico), [embedded](https://github.com/EmbeddedNim).
+* one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum),
+  [scientific computing](https://github.com/SciNim), [deep learning](https://github.com/mratsim/Arraymancer),
+  [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico),
+  [embedded](https://github.com/EmbeddedNim), see also some [companies using nim](https://github.com/nim-lang/Nim/wiki/Organizations-using-Nim).
 * concise and readable like Python: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
 * small binaries: `echo "hello world"` generates a 73K binary (or 5K with further options) (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -39,7 +39,7 @@ Why use Nim?
 
 Last but not least, macros let you manipulate/generate code at compile time instead of relying on code generators,
 enabling writing DSLs and language extensions in user code. Typical examples include implementing
-Python f-strings, optional chaining, command line generators, react-like Single Page Apps, protobuf serialization and binding generators [4].
+Python-like f-strings, optional chaining, command line generators, react-like Single Page Apps, protobuf serialization and binding generators [4].
 
 This release includes improvements in the following areas:
 * new language features (`iterable[T]`, user-defined literals, private imports, strict effects, dot-like operators, block arguments with optional parameters)

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -27,7 +27,7 @@ This release includes improvements in the following areas:
 * significant improvements in error messages, showing useful context
 * doc generation logic and documentation, in particular `runnableExamples` now works in more contexts and replaces `code-block`.
 * made JS, VM and nimscript backend more consistent with C backend, allowing more modules to work with those backends, including the imports from `std/prelude`; the test suite now standardizes on testing stdlib modules on each major backend (C, JS, VM).
-* support for Apple silicon/M1, 32-bit RISC-V, improved support for NodeJS backend
+* support for Apple silicon/M1, 32-bit RISC-V, CROSSOS, improved support for NodeJS backend
 * major improvements to the following modules: `system, math, random, json, jsonutils, os, typetraits, wrapnils, lists, hashes` including performance improvements
 * deprecated a number of error prone or redundant mis-features
 
@@ -64,7 +64,8 @@ The last command can be re-run after pulling new commits.
 Note that the `csources` repo used was changed to `csources_v1`, the new setup is designed to be forward and backward compatible.
 
 ## Building from a CI setup
-We now have an API to be used in CI which abstracts the implementation details: `. ci/funs.sh && nimBuildCsourcesIfNeeded`; in fact all the existing CI pipelines have been refactored to use this.
+We now have an API to be used in CI which abstracts the implementation details: `. ci/funs.sh && nimBuildCsourcesIfNeeded`; in fact all the existing CI pipelines have been refactored to use this, see
+[#17815](https://github.com/nim-lang/Nim/pull/17815).
 
 
 # Contributors to v1.6
@@ -606,6 +607,7 @@ Compatibility notes:
 ## OS-specific notes
 - Support for Apple silicon/M1.
 - Support for 32-bit RISC-V, refs [#16231](https://github.com/nim-lang/Nim/pull/16231).
+- Support for CROSSOS, refs [#18889](https://github.com/nim-lang/Nim/pull/18889).
 - The allocator for Nintendo Switch, which was nonfunctional because
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
 - Allow reading parameters when compiling for Nintendo Switch.

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -24,7 +24,7 @@ and best-in-class metaprogramming.
 Why use Nim?
 * one language to rule them all: from [shell scripting](https://nim-lang.org/docs/nims.html) to [web frontend and backend](https://github.com/nim-lang/nimforum), [scientific computing](https://github.com/SciNim), [machine learning](https://github.com/mratsim/Arraymancer), [blockchain client](https://github.com/status-im), [gamedev](https://github.com/ftsf/nico), [embedded](https://github.com/EmbeddedNim).
 * concise and readable like Python: `echo "hello world"` is a 1-liner (5 lines in C, C++, Go, Java).
-* small binaries: `echo "hello world"` generates a 73K binary (Go: 2MB, Rust: 377K, C++: 56K) [1].
+* small binaries: `echo "hello world"` generates a 73K binary (or 5K with further options) (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
 * C-like performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result), [ray tracing](https://nim-lang.org/blog/2020/06/30/ray-tracing-in-nim.html), [primes](https://github.com/PlummersSoftwareLLC/Primes)
 * no need for makefiles, cmake, configure or other build scripts, thanks to CTFE and dependency tracking [3]
@@ -882,7 +882,9 @@ func fn*(a: int): int = 42  ## Doc comment
 
 # Footnotes
 Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
-* [1] command used: `nim c -o:/tmp/main -d:danger --eval:'echo "hello world"'`
+* [1] command used: `nim c -o:/tmp/main -d:danger --eval:'echo "hello world"'`.
+  The binary size can be further reduced to 49K with stripping `--passL:-s` and link-time optimization (`--passC:-flto`).
+  Statically linking against `musl` brings it down to 5K, see https://irclogs.nim-lang.org/07-07-2020.html#12:31:34.
 * [2] commands used:
   for Nim: `nim c --forceBuild compiler/nim`
   for Rust: `./x.py build`, see also https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/

--- a/jekyll/_posts/2021-09-25-version-160-released.md
+++ b/jekyll/_posts/2021-09-25-version-160-released.md
@@ -71,7 +71,7 @@ We now have an API to be used in CI which abstracts the implementation details: 
 [#17815](https://github.com/nim-lang/Nim/pull/17815).
 
 
-# Contributors to v1.6
+# Contributors to Nim 1.6
 
 Many thanks to our recurring and new [contributors](https://github.com/nim-lang/Nim/graphs/contributors?from=2020-10-16&to=2021-09-25&type=c),
 Nim is a community driven collaborative effort that welcomes all contributions, big or small.


### PR DESCRIPTION
## notes for obtaining the stats:
* nb of packages:
```
git clone https://github.com/nim-lang/packages
cd packages
jq '. | length' packages.json
1732
```
then do same as of the time of 1.4 release (16 October 2020) and subtract from that
```nim
nim --eval:'echo 1732-1452'
280
```

* nb of commits since 1.4 release (f8890a0):
```
git rev-list f8890a0^..HEAD | wc -l
    1760
```
* PRs merged: https://github.com/search?q=repo%3Anim-lang%2Fnim+closed%3A%3E2020-10-16+is%3Apr+is%3Amerged&type=Issues
query: `repo:nim-lang/nim closed:>2020-10-16 is:pr is:merged`
* issues closed: https://github.com/search?q=repo%3Anim-lang%2Fnim+closed%3A%3E2020-10-16+is%3Aissue&type=Issues
query: `repo:nim-lang/nim closed:>2020-10-16 is:issue`
## links
* https://forum.nim-lang.org/t/8297
* https://www.tiobe.com/tiobe-index/
