### PR TITLE
1.6.0 release article: improve binary size section

### DIFF
--- a/jekyll/_posts/2021-10-19-version-160-released.md
+++ b/jekyll/_posts/2021-10-19-version-160-released.md
@@ -413,8 +413,8 @@ Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
 * [1] command used: `nim c -d:danger`.
   The binary size can be further reduced to 49K with stripping (`--passL:-s`)
   and link-time optimization (`--passC:-flto`).
-  Statically linking against `musl` brings it down to 5K, see
-  [link](https://irclogs.nim-lang.org/07-07-2020.html#12:31:34).
+  Statically linking against `musl` brings it under 5K - see
+  [here](https://github.com/ee7/binary-size) for more details.
 * [2] commands used:
   - for Nim: `nim c --forceBuild compiler/nim`
   - for Rust: `./x.py build`, [details](https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/)


### PR DESCRIPTION
Linking to an IRC discussion isn't great - when I linked to this previously, I didn't expect that it'd end up in the blog post. If we're going to mention numbers (and I think they're worth mentioning) we might as well make them reproducible.

In case it's preferred, I've created a repo that we could link to. I don't mind linking to a gist or something instead - but we can do better than that IRC link.

Previous discussion: https://github.com/nim-lang/website/pull/301#discussion_r718396305