### PR TITLE
Remove snap packages from Nim website

### DIFF
--- a/jekyll/install_unix.md
+++ b/jekyll/install_unix.md
@@ -192,26 +192,6 @@ pkg_add nim
 zypper in nim
 ```
 
-## Snap
-
-Get the latest stable release:
-
-```
-snap install nim-lang --classic
-```
-
-Get the latest LTS 1.0.x release:
-
-```
-snap install nim-lang-lts-1 --classic
-```
-
-Get the latest nightly build:
-
-```
-snap install nim-lang-nightly --classic
-```
-
 ## Void Linux
 
 ```


### PR DESCRIPTION
Average active monthly are about 200 users.

I maintained infrastructure to build and publish them at:

* https://github.com/sirredbeard/snap-build
* https://github.com/sirredbeard/nim_lang_snap

They were listed on the store at:

* https://snapcraft.io/nim-lang
* https://snapcraft.io/nim-lang-nightly
* https://snapcraft.io/nim-lang-lts-1

Current installs remain working.

The snap build container needs fixing and ongoing maintenance. The level of usage is an efficient use of time.

I am open to passing this off to someone else to maintain.