### PR TITLE
Remove Fedora

### DIFF
--- a/jekyll/install_unix.md
+++ b/jekyll/install_unix.md
@@ -162,12 +162,6 @@ The latest development version:
 docker pull nimlang/nim:devel
 ```
 
-## Fedora
-
-```
-dnf install nim
-```
-
 ## FreeBSD
 
 ```


### PR DESCRIPTION
Nim is not available in the Fedora repositories, the command fails, see https://packages.fedoraproject.org/search?query=nim.