### PR TITLE
split documentation to 2 parts

### DIFF
--- a/jekyll/_config.yml
+++ b/jekyll/_config.yml
@@ -26,14 +26,17 @@ defaults:
       title: "Nim Blog"
 
 navigation:
-  - title: Blog
-    url: /blog.html
+  
   - title: Features
     url: /features.html
+  - title: Learn
+    url: /learn.html
   - title: Download
     url: /install.html
   - title: Documentation
     url: /documentation.html
+  - title: Blog
+    url: /blog.html
   - title: Forum
     url: https://forum.nim-lang.org
   - title: Donate

--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -5,65 +5,6 @@ css_class: documentation
 ---
 <section class="pure-g content">
   <h1 class="pure-u-1 text-centered page-title main-heading">{{page.title}}</h1>
-
-  <div>
-    <div class="pure-u-1">
-      <h2>Getting started with Nim</h2>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://learnxinyminutes.com/docs/nim/">Learn Nim in 5 minutes</a></h3>
-      <p>A 5-minute tour through Nim.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://narimiran.github.io/nim-basics/">Nim basics tutorial</a></h3>
-      <p>For programming beginners. Covers all the basic topics, enough to make your first programming steps.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://play.nim-lang.org/">Official Nim Playground</a></h3>
-      <p>Compile and run Nim snippets in your browser.</p>
-    </div>
-  </div>
-
-  <div>
-    <div class="pure-u-1">
-      <h2>Official tutorials</h2>
-    </div>
-
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://nim-lang.org/docs/tut1.html">Tutorial, part 1</a></h3>
-      <p>A guide about basic and advanced built-in types, statements, control flow, and procedures.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://nim-lang.org/docs/tut2.html">Tutorial, part 2</a></h3>
-      <p>How to use Object Oriented Programming in Nim, exceptions, generics, and templates.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://nim-lang.org/docs/tut3.html">Macro tutorial</a></h3>
-      <p>Learn about meta-programming and macros.</p>
-    </div>
-  </div>
-
-  <div>
-    <div class="pure-u-1">
-      <h2>Nim for...</h2>
-    </div>
-
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://github.com/nim-lang/Nim/wiki/Nim-for-C-programmers">... C programmers</a></h3>
-      <p>This is a guide for people with experience in C or a similar language.
-      The guide assumes some intermediate knowledge, for instance of how stacks and heaps works.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://github.com/nim-lang/Nim/wiki/Nim-for-Python-Programmers">... Python programmers</a></h3>
-      <p>Nim is much more than "compiled Python", and this tutorial will give you an overview
-      of similarities and differences between the two languages.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://github.com/nim-lang/Nim/wiki/Nim-for-TypeScript-Programmers">... TypeScript/JavaScript programmers</a></h3>
-      <p>Want to use Nim for your frontend needs? Start here.</p>
-    </div>
-  </div>
-
   <div>
     <div class="pure-u-1">
       <h2>Documentation</h2>
@@ -80,94 +21,6 @@ css_class: documentation
     <div class="pure-u pure-u-md-1-3">
       <h3><a href="https://nim-lang.org/docs/tools.html">Tools Documentation</a></h3>
       <p>Description of some tools that come with the standard distribution.</p>
-    </div>
-  </div>
-
-  <div>
-    <div class="pure-u-1">
-      <h2>Search</h2>
-    </div>
-
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://nim-lang.org/docs/theindex.html">Searchable index</a></h3>
-      <p>All Nim documents and modules in one place. Use Ctrl/Cmd+F.</p>
-    </div>
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://nimble.directory/">Nimble Package Directory</a></h3>
-      <p>Search for available Nimble packages.</p>
-    </div>
-  </div>
-
-  <div>
-    <div class="pure-u-1">
-      <h2>Tutorials</h2>
-    </div>
-
-    <div class="row">
-      <div class="pure-u pure-u-md-1-3">
-        <h3><a href="http://howistart.org/posts/nim/1/index.html">How I Start: Nim</a></h3>
-        <p>Write an interpreter for the BrainF#@% programming language in Nim.</p>
-      </div>
-
-      <div class="pure-u pure-u-md-1-3">
-        <h3><a href="https://nim-by-example.github.io/getting_started/">Nim by Example</a></h3>
-        <p>A series of short examples covering the most common topics.</p>
-      </div>
-
-      <div class="pure-u pure-u-md-1-3">
-        <h3><a href="https://xmonader.github.io/nimdays/">Nim Days</a></h3>
-        <p>Building mini applications with Nim.</p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="pure-u pure-u-md-1-3">
-        <h3>
-          <a href="https://scripter.co/notes/nim">Nim Notes</a>
-        </h3>
-        <p>
-        A collection of Nim snippets with brief notes.
-        </p>
-      </div>
-
-      <div class="pure-u pure-u-md-1-3">
-        <h3>
-          <a href="http://zevv.nl/nim-memory/">Nim memory model</a>
-        </h3>
-        <p>
-        Tutorial explaining essentials of how Nim stores data in memory.
-        </p>
-      </div>
-
-      <div class="pure-u pure-u-md-1-3">
-        <h3>
-          <a href="https://www.youtube.com/playlist?list=PLvwc2YT9MFOlPPexrsY-t7BNTdg2Vsx06">Nim for Beginners</a>
-        </h3>
-        <p>
-        A video series meant to teach Nim programming to people
-        who have never programmed before, or are new to the language.
-        </p>
-      </div>
-    </div>
-  </div>
-
-  <div>
-    <div class="pure-u-1">
-      <h2>Blogs</h2>
-    </div>
-
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="http://goran.krampe.se/category/nim/">Goran Krampe</a></h3>
-      <p>OOP in Nim, Arduino and Nim, and more.</p>
-    </div>
-
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://hookrace.net/blog/nim/">HookRace</a></h3>
-      <p>NES emulator in Nim, SDL2 platformer, writing small binaries, etc.</p>
-    </div>
-
-    <div class="pure-u pure-u-md-1-3">
-      <h3><a href="https://peterme.net/">Peter's DevLog</a></h3>
-      <p>Options, File handling, stack vs heap (ref) objects, etc.</p>
     </div>
   </div>
 
@@ -214,8 +67,21 @@ css_class: documentation
         It also explains how to interface with libraries written in those languages.</p>
       </div>
     </div>
+  </div>
 
+  <div>
+    <div class="pure-u-1">
+      <h2>Search</h2>
+    </div>
 
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://nim-lang.org/docs/theindex.html">Searchable index</a></h3>
+      <p>All Nim documents and modules in one place. Use Ctrl/Cmd+F.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://nimble.directory/">Nimble Package Directory</a></h3>
+      <p>Search for available Nimble packages.</p>
+    </div>
   </div>
 
 

--- a/jekyll/learn.html
+++ b/jekyll/learn.html
@@ -1,6 +1,141 @@
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0; url=documentation.html">
-    <link rel="canonical" href="documentation.html" />
-  </head>
-</html>
+---
+title: "Learn"
+layout: page
+css_class: documentation
+---
+<section class="pure-g content">
+  <h1 class="pure-u-1 text-centered page-title main-heading">{{page.title}}</h1>
+
+  <div>
+    <div class="pure-u-1">
+      <h2>Getting started with Nim</h2>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://learnxinyminutes.com/docs/nim/">Learn Nim in 5 minutes</a></h3>
+      <p>A 5-minute tour through Nim.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://narimiran.github.io/nim-basics/">Nim basics tutorial</a></h3>
+      <p>For programming beginners. Covers all the basic topics, enough to make your first programming steps.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://play.nim-lang.org/">Official Nim Playground</a></h3>
+      <p>Compile and run Nim snippets in your browser.</p>
+    </div>
+  </div>
+
+  <div>
+    <div class="pure-u-1">
+      <h2>Official tutorials</h2>
+    </div>
+
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://nim-lang.org/docs/tut1.html">Tutorial, part 1</a></h3>
+      <p>A guide about basic and advanced built-in types, statements, control flow, and procedures.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://nim-lang.org/docs/tut2.html">Tutorial, part 2</a></h3>
+      <p>How to use Object Oriented Programming in Nim, exceptions, generics, and templates.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://nim-lang.org/docs/tut3.html">Macro tutorial</a></h3>
+      <p>Learn about meta-programming and macros.</p>
+    </div>
+  </div>
+
+  <div>
+    <div class="pure-u-1">
+      <h2>Nim for...</h2>
+    </div>
+
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://github.com/nim-lang/Nim/wiki/Nim-for-C-programmers">... C programmers</a></h3>
+      <p>This is a guide for people with experience in C or a similar language.
+      The guide assumes some intermediate knowledge, for instance of how stacks and heaps works.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://github.com/nim-lang/Nim/wiki/Nim-for-Python-Programmers">... Python programmers</a></h3>
+      <p>Nim is much more than "compiled Python", and this tutorial will give you an overview
+      of similarities and differences between the two languages.</p>
+    </div>
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://github.com/nim-lang/Nim/wiki/Nim-for-TypeScript-Programmers">... TypeScript/JavaScript programmers</a></h3>
+      <p>Want to use Nim for your frontend needs? Start here.</p>
+    </div>
+  </div>
+
+  <div>
+    <div class="pure-u-1">
+      <h2>Tutorials</h2>
+    </div>
+
+    <div class="row">
+      <div class="pure-u pure-u-md-1-3">
+        <h3><a href="http://howistart.org/posts/nim/1/index.html">How I Start: Nim</a></h3>
+        <p>Write an interpreter for the BrainF#@% programming language in Nim.</p>
+      </div>
+
+      <div class="pure-u pure-u-md-1-3">
+        <h3><a href="https://nim-by-example.github.io/getting_started/">Nim by Example</a></h3>
+        <p>A series of short examples covering the most common topics.</p>
+      </div>
+
+      <div class="pure-u pure-u-md-1-3">
+        <h3><a href="https://xmonader.github.io/nimdays/">Nim Days</a></h3>
+        <p>Building mini applications with Nim.</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="pure-u pure-u-md-1-3">
+        <h3>
+          <a href="https://scripter.co/notes/nim">Nim Notes</a>
+        </h3>
+        <p>
+        A collection of Nim snippets with brief notes.
+        </p>
+      </div>
+
+      <div class="pure-u pure-u-md-1-3">
+        <h3>
+          <a href="http://zevv.nl/nim-memory/">Nim memory model</a>
+        </h3>
+        <p>
+        Tutorial explaining essentials of how Nim stores data in memory.
+        </p>
+      </div>
+
+      <div class="pure-u pure-u-md-1-3">
+        <h3>
+          <a href="https://www.youtube.com/playlist?list=PLvwc2YT9MFOlPPexrsY-t7BNTdg2Vsx06">Nim for Beginners</a>
+        </h3>
+        <p>
+        A video series meant to teach Nim programming to people
+        who have never programmed before, or are new to the language.
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <div class="pure-u-1">
+      <h2>Blogs</h2>
+    </div>
+
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="http://goran.krampe.se/category/nim/">Goran Krampe</a></h3>
+      <p>OOP in Nim, Arduino and Nim, and more.</p>
+    </div>
+
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://hookrace.net/blog/nim/">HookRace</a></h3>
+      <p>NES emulator in Nim, SDL2 platformer, writing small binaries, etc.</p>
+    </div>
+
+    <div class="pure-u pure-u-md-1-3">
+      <h3><a href="https://peterme.net/">Peter's DevLog</a></h3>
+      <p>Options, File handling, stack vs heap (ref) objects, etc.</p>
+    </div>
+  </div>
+
+
+</section>


### PR DESCRIPTION
adjust navigation

for beginner:
they see features -> learn a bit of nim -> install it try play with 

for non-beginner:

click Documentation , check manual and document references directly.

it's a bit weird feeling, click "Documentation" and see "Getting started with Nim" for me.

refs: https://github.com/nim-lang/website/issues/318 likely fit this 

maybe add more commit to cover #242 in this PR as well. after investigation it's not a stable choice for putting it into main navigation. but put "Nimble Package Manager" and "Nimble Package Directory" sections together seems to be a improvement to me.

change "Documentation" to "Docs" and "Download" to "Install" make the navigation shorter, might not feel hesitant for adding extro "Packages" link.

and another thing I noticed is "Community" seems to be a stable choice putting into main navigation on language offical sites.