### PR TITLE
version-20-rc: update binary size measurements

### DIFF
--- a/jekyll/_posts/2022-12-21-version-20-rc.md
+++ b/jekyll/_posts/2022-12-21-version-20-rc.md
@@ -30,7 +30,7 @@ On the other hand, if you waited until version 2.0 to explore Nim, here are some
   [embedded](https://github.com/EmbeddedNim), see also some
   [companies using Nim](https://github.com/nim-lang/Nim/wiki/Organizations-using-Nim).
 * Concise, readable and convenient: `echo "hello world"` is a 1-liner.
-* Small binaries: `echo "hello world"` generates a 73K binary (or 5K with further options),
+* Small binaries: `echo "hello world"` generates a 72K binary (or around 5K with further options),
   optimized for embedded devices (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * Fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
 * Native performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result),
@@ -823,13 +823,12 @@ These reported issues were fixed:
 
 # Footnotes
 
-Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM.
-* [1] command used: `nim c -d:danger`.
-  The binary size can be further reduced to 49K with stripping (`--passL:-s`)
+* [1] command used: `nim c -d:release`.
+  The binary size can be further reduced to 35K with stripping (`--passL:-s`)
   and link-time optimization (`--passC:-flto`).
-  Statically linking against `musl` brings it under 5K - see
+  Statically linking against `musl` brings it to about 5K - see
   [here](https://github.com/ee7/binary-size) for more details.
-* [2] commands used:
+* [2] Tested on a 2.3 GHz 8-Core Intel Core i9, 2019 macOS 11.5 with 64GB RAM. Commands used:
   - for Nim: `nim c --forceBuild compiler/nim`
   - for Rust: `./x.py build`, [details](https://www.reddit.com/r/rust/comments/76jq7h/long_time_to_compile_rustc/)
   - for GCC: see [1](https://unix.stackexchange.com/questions/421822/how-long-does-it-take-to-compile-gcc-7-3-0)


### PR DESCRIPTION
The blog post for Nim 2.0.0 RC1 used binary size measurements that were taken from the [blog post for Nim 1.6.0][1] (2021-10-19). Update the data for Nim 2.0.0 RC1 (and RC2).

Also, mention `-d:release` rather than `-d:danger`. The [referenced repo][2] made that change for the first optimized build options. Rationale: we can save a few more KiB with `-d:danger`, but that's not worth giving any impression that "Nim binaries are only small in danger mode".

[1]: https://nim-lang.org/blog/2021/10/19/version-160-released.html#why-use-nim
[2]: https://github.com/ee7/binary-size

---

Avoid otherwise-inevitable comments of "yes, the Nim binary is smaller, but it isn't even safe".