### PR TITLE
version-20-rc: use binary size data for Linux, not macOS

### DIFF
--- a/jekyll/_posts/2022-12-21-version-20-rc.md
+++ b/jekyll/_posts/2022-12-21-version-20-rc.md
@@ -30,7 +30,7 @@ On the other hand, if you waited until version 2.0 to explore Nim, here are some
   [embedded](https://github.com/EmbeddedNim), see also some
   [companies using Nim](https://github.com/nim-lang/Nim/wiki/Organizations-using-Nim).
 * Concise, readable and convenient: `echo "hello world"` is a 1-liner.
-* Small binaries: `echo "hello world"` generates a 72K binary (or around 5K with further options),
+* Small binaries: `echo "hello world"` generates a 67K binary (or around 5K with further options),
   optimized for embedded devices (Go: 2MB, Rust: 377K, C++: 56K) [1].
 * Fast compile times: a full compiler rebuild takes ~12s (Rust: 15min, gcc: 30min+, clang: 1hr+, Go: 90s) [2].
 * Native performance: see [Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result),


### PR DESCRIPTION
Make the OS consistent.

Commit c02758d0db10 didn't update this number properly. It should use the Linux data point, not the macOS one, since the "around 5K" figure is for Linux (and so is the later 35K figure in the footnote).

---

I messed up in the previous commit - sorry.

Data: https://github.com/ee7/binary-size#results