### PR TITLE
documentation: add Exercism to learning resources again

### DIFF
--- a/jekyll/documentation.html
+++ b/jekyll/documentation.html
@@ -215,6 +215,13 @@ css_class: documentation
       </div>
     </div>
 
+    <div class="row">
+      <div class="pure-u pure-u-md-1-3">
+        <h3><a href="https://exercism.org/tracks/nim">Nim exercises on Exercism</a></h3>
+        <p>Learn and practice Nim by solving small exercises, either in the browser or locally.
+        Exercism is a 100% free, open-source, not-for-profit organization.</p>
+      </div>
+    </div>
 
   </div>
 


### PR DESCRIPTION
In 2019, the website gained a Learn page (32bd297fe325) that mentioned [Exercism's Nim track](https://exercism.org/tracks/nim).

However, commit 260adcf72fd2 unified the Learn and documentation page as https://nim-lang.org/documentation.html, and removed the Exercism mention.

---

Can we add this again? If so: I put it in a new row under the "Other" heading, at the very bottom. Is there a better place?

If not: please let me know if there's any improvement to the track that could allow its inclusion on this page. I am a [maintainer of the track](https://github.com/exercism/nim/graphs/contributors). The track is far from perfect, but I think it's still a good learning resource.

Among other languages, I know at least [Elixir's learning page](https://elixir-lang.org/learning.html#other-resources) mentions its Exercism track.