### PR TITLE
Update one forgetten`Nim1.6` to `Nim2.0` in `install page`

### DIFF
--- a/jekyll/install.md
+++ b/jekyll/install.md
@@ -55,7 +55,7 @@ css_class: install
 <div class="slim content center">
   <div class="pure-u pure-u-md-1-3">
     <h2>Windows</h2>
-    Nim 1.6:
+    Nim 2.0:
     <ul>
       <li>Nim 2.0.0:
       <a href="{{ site.baseurl }}/download/nim-2.0.0_x64.zip">64-bit</a>,


### PR DESCRIPTION
I'm coming from <https://nim-lang.org/install.html>  
because I found something mistaken:  
as is shown in this PR  
* in `<h2>`s of the `<h1>`: `Install previous versions`, `Unix`'s was correctly updated to `Nim2.0` while `Windows`'s was not

@narimiran I do wish this be fixed soon in case it confuses those who visit Official Website.  
<sub>Sorry to open a PR for such a small typo. I just think it urgent. </sub>