### PR TITLE
2.0.2, 2.0.4: clarify -d:useMalloc requirement

### DIFF
--- a/jekyll/_posts/2023-12-19-versions-1618-202-released.md
+++ b/jekyll/_posts/2023-12-19-versions-1618-202-released.md
@@ -11,7 +11,7 @@ The Nim team is happy to announce two releases:
 For the majority of our users, v2.0.2 contains [63 commits](https://github.com/nim-lang/Nim/compare/v2.0.0...v2.0.2) and brings bugfixes and improvements to Nim 2.0.0, released four months ago.
 
 **NOTE**: If your program uses threads (`--threads:on` became the default in the 2.0.x line) please also use the `-d:useMalloc` switch.
-This problem will be fixed in 2.0.4, sorry for the inconvenience.
+This problem will be fixed in a future release, sorry for the inconvenience.
 
 
 For those users who haven't switched to [Nim v2.0](https://nim-lang.org/blog/2023/08/01/nim-v20-released.html) yet, we have released the ninth patch release for Nim 1.6.x.

--- a/jekyll/_posts/2024-04-16-versions-1620-204-released.md
+++ b/jekyll/_posts/2024-04-16-versions-1620-204-released.md
@@ -10,6 +10,8 @@ The Nim team is happy to announce two releases:
 
 For the majority of our users, v2.0.4 contains [23 commits](https://github.com/nim-lang/Nim/compare/v2.0.2...v2.0.4) and brings bugfixes and improvements to Nim 2.0.2, released four months ago.
 
+**NOTE**: If your program uses threads (`--threads:on` became the default in the 2.0.x line) please also use the `-d:useMalloc` switch.
+This problem will be fixed in a future release, sorry for the inconvenience.
 
 For those users who haven't switched to [Nim v2.0](https://nim-lang.org/blog/2023/08/01/nim-v20-released.html) yet, we have released the ninth patch release for Nim 1.6.x.
 It is a small release with [13 commits](https://github.com/nim-lang/Nim/compare/v1.6.18...v1.6.20).


### PR DESCRIPTION
The 2.0.2 release post noted a particular problem, saying it'd be fixed in 2.0.4. It wasn't, so reduce the potential confusion: amend the note for 2.0.2, and add the same note for 2.0.4 (on the basis that if it was worth mentioning for 2.0.2, I guess it's still worth mentioning later).

My understanding is that the regression still exists in 2.0.4, and [Araq said on the forum][1]:

>This example is supposed to work and does when you disable Nim's broken default allocator.
>
>That is a regression with the 2.0 line. You really need `-d:useMalloc` for the time being, sorry. I've "fixed" this bug months ago but it causes other test regressions.

See also [the commits between 2.0.2 and 2.0.4][2].

[1]: https://forum.nim-lang.org/t/11374#74050
[2]: https://github.com/nim-lang/Nim/compare/v2.0.2...v2.0.4

---

Feel free to take over this PR. No worries that the problem wasn't resolved - it's just that when I saw the 2.0.4 release, I initially thought it was.