### PR TITLE
Eliminate label="basic"

### DIFF
--- a/jekyll/code_carrousel.html
+++ b/jekyll/code_carrousel.html
@@ -15,7 +15,7 @@
 
 
 <select class="pure-button" onchange="showcodesample(this.selectedIndex)">
-  <optgroup label="Basic">
+  <optgroup>
     <option>Simple example</option>
     <option>If…else, Case switch</option>
     <option>Basic math</option>


### PR DESCRIPTION
It's doesn't do anything, and it isn't really visual appealing for the user when he looks at the selection of snippets.