### PR TITLE
Delete <optgroup> from jekyll/code_carrousel.html

### DIFF
--- a/jekyll/code_carrousel.html
+++ b/jekyll/code_carrousel.html
@@ -15,14 +15,12 @@
 
 
 <select class="pure-button" onchange="showcodesample(this.selectedIndex)">
-  <optgroup>
-    <option>Simple example</option>
-    <option>If…else, Case switch</option>
-    <option>Basic math</option>
-    <option>String operations</option>
-    <option>Comprehensions</option>
-    <!-- Add more examples by adding an option here -->
-  </optgroup>
+  <option>Simple example</option>
+  <option>If…else, Case switch</option>
+  <option>Basic math</option>
+  <option>String operations</option>
+  <option>Comprehensions</option>
+  <!-- Add more examples by adding an option here -->
 </select>
 
 


### PR DESCRIPTION
I previously contributed, #413, by eliminating the label which said "Basic" in `<optgroup>`, but I didn't think that this would create a whitespace, which it has done. Here is the code fix to eliminate this whitespace.

# Before
<img width="543" alt="Screenshot 2025-02-15 at 16 13 04" src="https://github.com/user-attachments/assets/d3588587-c991-4af0-8559-200e1e664cba" />

# After
<img width="562" alt="Screenshot 2025-02-15 at 16 12 54" src="https://github.com/user-attachments/assets/5c61329b-e964-4da6-85e7-fefdeeeb74a6" />