### PR TITLE
Make text match corresponding colour

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -20,7 +20,7 @@ use_dark_highlighting: true
           <a class="pure-button pure-button-primary" href="{{ site.baseurl }}/install.html">Install Nim {{ site.nim_version }}</a>
           <a class="pure-button" href="https://play.nim-lang.org/#ix=2lK1">Try it online</a>
         </div>
-        <h3>Efficient</h3>
+        <h3 style="color:#ffe953;">Efficient</h3>
         <ul>
           <li>Nim generates native dependency-free executables, not dependent on a virtual machine,
               which are small and allow easy redistribution.</li>
@@ -35,13 +35,13 @@ use_dark_highlighting: true
           <li>Support for various backends: it compiles to C, C++ or JavaScript so that Nim
               can be used for all backend and frontend needs.</li>
         </ul>
-        <h3>Expressive</h3>
+        <h3 style="color:#ffe953;">Expressive</h3>
         <ul>
           <li>Nim is self-contained: the compiler and the standard library are implemented in Nim.</li>
           <li>Nim has a powerful macro system which allows direct manipulation of the AST,
               offering nearly unlimited opportunities.</li>
         </ul>
-        <h3>Elegant</h3>
+        <h3 style="color:#ffe953;">Elegant</h3>
         <ul>
           <li>Macros cannot change Nim's syntax because there is no need for it —
               the syntax is flexible enough.</li>


### PR DESCRIPTION
On the website the text "Efficient, expressive, elegant" is set with the colour from the Nim logo. After another text each one of this words is broken-down/explained, but with the colour white. I think the yellow would match more!

# Before
<img width="598" alt="Screenshot 2025-02-16 at 18 53 49" src="https://github.com/user-attachments/assets/1e427bb4-069d-4049-949c-45b24cef84cb" />

# After
<img width="612" alt="Screenshot 2025-02-16 at 18 53 34" src="https://github.com/user-attachments/assets/3afb5234-83ac-4654-b957-c611e32e18d3" />
