### PR TITLE
Add "nim-lang/website" link in Bug Report section

### DIFF
--- a/jekyll/index.html
+++ b/jekyll/index.html
@@ -160,6 +160,8 @@ use_dark_highlighting: true
         <h2>Bug reports</h2>
         <p><a href="https://github.com/nim-lang/Nim/issues">
           <i class="fab fa-github" aria-hidden="true"></i>nim-lang/Nim</a></p>
+        <p><a href="https://github.com/nim-lang/website/issues">
+          <i class="fab fa-github" aria-hidden="true"></i>nim-lang/website</a></p>
       </div>
 
       <div class="pure-u-1 pure-u-md-1-4">


### PR DESCRIPTION
The official Nim repo is already linked there for bug reports, but it would also make sense to have the repo linked, specially considering the user is in the website. It would look like this now.
<img width="1435" alt="Screenshot 2025-02-17 at 23 01 45" src="https://github.com/user-attachments/assets/784e7720-8a5b-41ec-9b7e-01a9f616c190" />
